### PR TITLE
removed invalid relative parent path

### DIFF
--- a/CalendarFXApp/pom.xml
+++ b/CalendarFXApp/pom.xml
@@ -8,7 +8,6 @@
 		<groupId>com.calendarfx</groupId>
 		<artifactId>calendar</artifactId>
 		<version>8.4.1</version>
-		<relativePath>../CalendarFX</relativePath>
 	</parent>
 
 	<dependencies> 


### PR DESCRIPTION
build fails because of invalid parent path. You will notice that only if there is no calendarsfx artifact in your local repository.