### PR TITLE
renamed CalendarFXView to CalendarFXExperimental

### DIFF
--- a/CalendarFXExperimental/pom.xml
+++ b/CalendarFXExperimental/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>experimental</artifactId>
-	<name>CalendarFXView</name>
+	<name>CalendarFXExperimental</name>
 
 	<parent>
 		<groupId>com.calendarfx</groupId>


### PR DESCRIPTION
Simple rename to not to have duplicate entries in IDEA's Maven Project View.

Uhm ... sorry for flooding with micro PR :-( 