### PR TITLE
immediately update UI if just the calendar of an entry changes

### DIFF
--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
@@ -478,7 +478,7 @@ public class DayViewSkin<T extends DayView> extends DayViewBaseSkin<T> implement
             getSkinnable().requestLayout();
         }
 
-        if (evt.isEntryAdded()) {
+        if (evt.isEntryAdded() && isRelevant(entry)) {
             addEntryView(entry);
         }
 

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
@@ -478,8 +478,11 @@ public class DayViewSkin<T extends DayView> extends DayViewBaseSkin<T> implement
             getSkinnable().requestLayout();
         }
 
-        if (evt.isEntryAdded() && isRelevant(entry)) {
+        if (evt.isEntryAdded()) {
             addEntryView(entry);
+        }
+
+        if (isRelevant(entry)) {
             getSkinnable().requestLayout();
         }
     }


### PR DESCRIPTION
If you change just the "calendar" of an entry the change is not immediately reflected in the UI.

Steps to reproduce:

Start the CalendarFXSampler
Navigate to Performance/Performance
Switch layout to swimlane
create two entries at the same time at the same day
change the calendar of one entry .... nothings happens until you click the event