### PR TITLE
drag/drop issues

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
@@ -373,7 +373,7 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
 		 * We might run in the sampler application. Then the entry view will not
 		 * be inside a date control.
 		 */
-		if (control != null) {
+		if (control != null && getParent() != null) {
 			Callback<EntryDetailsParameter, Boolean> callback = control.getEntryDetailsCallback();
 			EntryDetailsParameter param = new EntryDetailsParameter(evt, control, getEntry(), getParent(), x, y);
 			callback.call(param);

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
@@ -24,6 +24,7 @@ public class DayViewEditController {
 
     private static final Logger LOGGER = LoggingDomain.EDITING;
 
+    private boolean dragging;
     private DayViewBase dayView;
     private DayEntryView dayEntryView;
     private Entry<?> entry;
@@ -80,7 +81,9 @@ public class DayViewEditController {
     }
 
     private void mouseMoved(MouseEvent evt) {
-        initDragModeAndHandle(evt);
+        if (!dragging) {
+            initDragModeAndHandle(evt);
+        }
 
         if (handle == null) {
             return;
@@ -125,6 +128,7 @@ public class DayViewEditController {
         if (dragMode == null) {
             return;
         }
+        dragging = true;
 
         switch (dragMode) {
             case START_AND_END_TIME:
@@ -161,6 +165,7 @@ public class DayViewEditController {
 
 
     private void mouseReleased(MouseEvent evt) {
+        dragging = false;
         if (!evt.getButton().equals(MouseButton.PRIMARY) || dayEntryView == null || dragMode == null) {
             return;
         }
@@ -303,6 +308,11 @@ public class DayViewEditController {
 
     private void changeStartAndEndTime(MouseEvent evt) {
         DraggedEntry draggedEntry = dayView.getDraggedEntry();
+        if (draggedEntry == null) {
+            // we might see "mouse dragged" events close before "mouse pressed". in this case, our drag/dro handling
+            // has not been fully initialized yet.
+            return;
+        }
         LocalDateTime locationTime = dayView.getZonedDateTimeAt(evt.getX(), evt.getY()).toLocalDateTime();
 
         LOGGER.fine("changing start/end time, time = " + locationTime //$NON-NLS-1$

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
@@ -201,6 +201,12 @@ public class DayViewEditController {
             return;
         }
 
+        if (dayView.getDraggedEntry() == null) {
+            // we might see "mouse dragged" events close before "mouse pressed". in this case, our drag/dro handling
+            // has not been fully initialized yet.
+            return;
+        }
+
         switch (dragMode) {
             case START_TIME:
                 switch (handle) {
@@ -308,11 +314,6 @@ public class DayViewEditController {
 
     private void changeStartAndEndTime(MouseEvent evt) {
         DraggedEntry draggedEntry = dayView.getDraggedEntry();
-        if (draggedEntry == null) {
-            // we might see "mouse dragged" events close before "mouse pressed". in this case, our drag/dro handling
-            // has not been fully initialized yet.
-            return;
-        }
         LocalDateTime locationTime = dayView.getZonedDateTimeAt(evt.getX(), evt.getY()).toLocalDateTime();
 
         LOGGER.fine("changing start/end time, time = " + locationTime //$NON-NLS-1$


### PR DESCRIPTION
On the Performance sample app I switched to week view and created a single entry.
When I am dragging and dropping this entry like a very nervous person I managed to leave back "ghosts" of the entry. Also when dragging/dropping the start or end time very nervous I saw some NPEs in the console.
This patch fixed all of these issues.

It came down to the fact that it is possible that you get mouseMoved events before the mouseReleased event even in drag mode.
In this case the initDragModeAndHandle set the dragMode to null too early and it looked like as if there was no dragging action active at all.
I also saw mouseDragged before mousePressed.

This patch introduces a boolean "dragging" which is set and unset in mousePressed/mouseReleased and, as long as this boolean is true, in mouseMoved the dragMode will not be reset.

I hope I was able to describe the issue good enough.

Java: Java 1.8.0_152-ea-b05
OS: macOS 10.13