### PR TITLE
DetailedWeekView adjustToFirstDayOfWeek and Entry equation

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
@@ -922,7 +922,9 @@ public class Entry<T> implements Comparable<Entry<?>> {
                 public void set(T newObject) {
                     T oldUserObject = get();
 
-                    if (!Util.equals(oldUserObject, newObject)) {
+                    // We do not use .equals() here to allow to reset the object even if is "looks" the same e.g. if it
+                    // has some .equals() method implemented which just compares an id/business key.
+                    if (oldUserObject != newObject) {
                         super.set(newObject);
 
                         Calendar calendar = getCalendar();

--- a/CalendarFXView/src/main/java/com/calendarfx/view/DetailedWeekView.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DetailedWeekView.java
@@ -82,14 +82,17 @@ public class DetailedWeekView extends DayViewBase {
         weekDayHeaderView = new WeekDayHeaderView();
         bind(weekDayHeaderView, true);
         Bindings.bindBidirectional(weekDayHeaderView.numberOfDaysProperty(), numberOfDaysProperty());
+        Bindings.bindBidirectional(weekDayHeaderView.adjustToFirstDayOfWeekProperty(), adjustToFirstDayOfWeekProperty());
 
         allDayView = new AllDayView(getNumberOfDays());
         bind(allDayView, true);
         Bindings.bindBidirectional(allDayView.numberOfDaysProperty(), numberOfDaysProperty());
+        Bindings.bindBidirectional(allDayView.adjustToFirstDayOfWeekProperty(), adjustToFirstDayOfWeekProperty());
 
         weekView = new WeekView();
         bind(weekView, true);
         Bindings.bindBidirectional(weekView.numberOfDaysProperty(), numberOfDaysProperty());
+        Bindings.bindBidirectional(weekView.adjustToFirstDayOfWeekProperty(), adjustToFirstDayOfWeekProperty());
 
         timeScaleView = new WeekTimeScaleView();
         bind(timeScaleView, true);

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/AllDayViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/AllDayViewSkin.java
@@ -73,6 +73,7 @@ public class AllDayViewSkin extends DateControlSkin<AllDayView> implements LoadD
         view.numberOfDaysProperty().addListener(updateBackgroundsListener);
         view.showTodayProperty().addListener(updateBackgroundsListener);
         view.weekFieldsProperty().addListener(updateBackgroundsListener);
+        view.adjustToFirstDayOfWeekProperty().addListener(updateBackgroundsListener);
 
         // update entries
         InvalidationListener updateEntriesListener = evt -> updateEntries("a view property changed");
@@ -83,6 +84,7 @@ public class AllDayViewSkin extends DateControlSkin<AllDayView> implements LoadD
         view.rowSpacingProperty().addListener(updateEntriesListener);
         view.columnSpacingProperty().addListener(updateEntriesListener);
         view.weekFieldsProperty().addListener(updateEntriesListener);
+        view.adjustToFirstDayOfWeekProperty().addListener(updateEntriesListener);
 
         updateBackgrounds();
 

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/WeekDayHeaderViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/WeekDayHeaderViewSkin.java
@@ -49,6 +49,7 @@ public class WeekDayHeaderViewSkin extends SkinBase<WeekDayHeaderView> {
         view.showTodayProperty().addListener(updateListener);
         view.weekFieldsProperty().addListener(updateListener);
         view.enableHyperlinksProperty().addListener(updateListener);
+        view.adjustToFirstDayOfWeekProperty().addListener(updateListener);
 
         updateControl();
     }


### PR DESCRIPTION
DetailedWeekView: missing binding of adjustToFirstDayOfWeek of child views missing
Entry: Use identity equation instead. See comment in code. (I thought I've already pulled that?)