### PR TITLE
Fixed issues regarding the Drag and Drop of the entry at the start and end of it

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
@@ -16,6 +16,30 @@
 
 package com.calendarfx.view;
 
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.util.Objects.requireNonNull;
+import static javafx.scene.input.ContextMenuEvent.CONTEXT_MENU_REQUESTED;
+
+import java.text.MessageFormat;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.controlsfx.control.PopOver;
+import org.controlsfx.control.PopOver.ArrowLocation;
+import org.controlsfx.control.PropertySheet.Item;
+
 import com.calendarfx.model.Calendar;
 import com.calendarfx.model.CalendarSource;
 import com.calendarfx.model.Entry;
@@ -24,6 +48,7 @@ import com.calendarfx.util.LoggingDomain;
 import com.calendarfx.view.page.DayPage;
 import com.calendarfx.view.popover.DatePopOver;
 import com.calendarfx.view.popover.EntryPopOverContentPane;
+
 import impl.com.calendarfx.view.ViewHelper;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -59,31 +84,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Callback;
-import org.controlsfx.control.PopOver;
-import org.controlsfx.control.PopOver.ArrowLocation;
-import org.controlsfx.control.PropertySheet.Item;
-
-import java.text.MessageFormat;
-import java.time.DayOfWeek;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.WeekFields;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.time.DayOfWeek.SATURDAY;
-import static java.time.DayOfWeek.SUNDAY;
-import static java.util.Objects.requireNonNull;
-import static javafx.scene.control.SelectionMode.MULTIPLE;
-import static javafx.scene.input.ContextMenuEvent.CONTEXT_MENU_REQUESTED;
-import static javafx.scene.input.MouseButton.PRIMARY;
 
 /**
  * The superclass for all controls that are showing calendar information. This
@@ -425,7 +425,6 @@ public abstract class DateControl extends CalendarFXControl {
 
         addEventFilter(MouseEvent.MOUSE_PRESSED, evt -> {
             maybeHidePopOvers();
-            performSelection(evt);
         });
     }
 
@@ -462,48 +461,6 @@ public abstract class DateControl extends CalendarFXControl {
         getBoundDateControls().forEach(DateControl::refreshData);
     }
 
-    private void performSelection(MouseEvent evt) {
-        if ((evt.getButton().equals(PRIMARY) || evt.isPopupTrigger()) && evt.getClickCount() == 1) {
-
-            Entry<?> entry;
-            EntryViewBase<?> view = null;
-
-            if (evt.getTarget() instanceof EntryViewBase) {
-                view = (EntryViewBase<?>) evt.getTarget();
-            }
-
-            if (view == null) {
-                return;
-            }
-
-            String disableFocusHandlingKey = "disable-focus-handling"; //$NON-NLS-1$
-
-            view.getProperties().put(disableFocusHandlingKey, true);
-            view.requestFocus();
-
-            entry = view.getEntry();
-
-            if (entry != null) {
-
-                if (!isMultiSelect(evt) && !getSelections().contains(entry)) {
-                    clearSelection();
-                }
-
-                if (isMultiSelect(evt) && getSelections().contains(entry)) {
-                    getSelections().remove(entry);
-                } else if (!getSelections().contains(entry)) {
-                    getSelections().add(entry);
-                }
-            }
-
-            view.getProperties().remove(disableFocusHandlingKey);
-
-        }
-    }
-
-    private boolean isMultiSelect(MouseEvent evt) {
-        return (evt.isShiftDown() || evt.isShortcutDown()) && getSelectionMode().equals(MULTIPLE);
-    }
 
     /**
      * Creates a new calendar source that will be added to the list of calendar

--- a/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
@@ -968,15 +968,15 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
             
             DateControl control = getDateControl();
             
-            if (!isMultiSelect(evt)) {
+            if (!isMultiSelect(evt) && !control.getSelections().contains(entry)) {
                 control.clearSelection();
-                control.getSelections().add(entry);
-            }else{
-                if(control.getSelections().contains(entry))
-                    control.deselect(entry);
-                else 
-                    control.getSelections().add(entry);
             }
+            
+            if(isMultiSelect(evt) && control.getSelections().contains(entry))
+                control.deselect(entry);
+            else if (!control.getSelections().contains(entry))
+                control.getSelections().add(entry);
+            
             getProperties().remove(disableFocusHandlingKey);
         }
     }

--- a/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
@@ -16,10 +16,22 @@
 
 package com.calendarfx.view;
 
+import static java.util.Objects.requireNonNull;
+import static javafx.scene.control.SelectionMode.MULTIPLE;
+import static javafx.scene.input.MouseButton.PRIMARY;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.controlsfx.control.PropertySheet;
+import org.controlsfx.control.PropertySheet.Item;
+
 import com.calendarfx.model.Calendar;
 import com.calendarfx.model.Entry;
 import com.calendarfx.view.DateControl.EntryContextMenuParameter;
 import com.calendarfx.view.DateControl.EntryDetailsParameter;
+
 import javafx.animation.ScaleTransition;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
@@ -45,14 +57,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Callback;
 import javafx.util.Duration;
-import org.controlsfx.control.PropertySheet;
-import org.controlsfx.control.PropertySheet.Item;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * The base class for all views that are representing calendar entries. There
@@ -212,6 +216,8 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
             boolean contains = selections.contains(entry);
             selected.set(contains);
         });
+        
+        addEventHandler(MouseEvent.MOUSE_PRESSED, this::performSelection);
 
         bindEntry(entry);
     }
@@ -953,4 +959,30 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
 
         return items;
     }
+
+    private void performSelection(MouseEvent evt) {
+        if ((evt.getButton().equals(PRIMARY) || evt.isPopupTrigger()) && evt.getClickCount() == 1) {
+            String disableFocusHandlingKey = "disable-focus-handling";
+            getProperties().put(disableFocusHandlingKey, true);
+            requestFocus();
+            
+            DateControl control = getDateControl();
+            
+            if (!isMultiSelect(evt)) {
+                control.clearSelection();
+                control.getSelections().add(entry);
+            }else{
+                if(control.getSelections().contains(entry))
+                    control.deselect(entry);
+                else 
+                    control.getSelections().add(entry);
+            }
+            getProperties().remove(disableFocusHandlingKey);
+        }
+    }
+    
+    private boolean isMultiSelect(MouseEvent evt) {
+        return (evt.isShiftDown() || evt.isShortcutDown()) && getDateControl().getSelectionMode().equals(MULTIPLE);
+    }
+    
 }

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 
 import com.calendarfx.model.Calendar;
 import com.calendarfx.model.Entry;
-import com.calendarfx.model.Interval;
 import com.calendarfx.util.LoggingDomain;
 import com.calendarfx.view.DateControl;
 import com.calendarfx.view.DayEntryView;
@@ -314,12 +313,11 @@ public class DayViewEditController {
 
         DraggedEntry draggedEntry = dayView.getDraggedEntry();
 
-        if (isMinimumDuration(entry, entry.getEndAsLocalDateTime(), locationTime)) {
+        if (isMinimumDuration(entry, entry.getEndAsLocalDateTime(),
+                locationTime)) {
 
-            Interval interval = draggedEntry.getInterval();
-
-            LocalDate startDate = interval.getStartDate();
-            LocalDate endDate = interval.getEndDate();
+            LocalDate startDate;
+            LocalDate endDate;
 
             LocalTime startTime;
             LocalTime endTime;
@@ -360,12 +358,10 @@ public class DayViewEditController {
         if (isMinimumDuration(entry, entry.getStartAsLocalDateTime(),
                 locationTime)) {
 
-            Interval interval = draggedEntry.getInterval();
-
             LOGGER.finer("dragged entry: " + draggedEntry.getInterval());
 
-            LocalDate startDate = interval.getStartDate();
-            LocalDate endDate = interval.getEndDate();
+            LocalDate startDate;
+            LocalDate endDate;
 
             LocalTime startTime;
             LocalTime endTime;

--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ Property files used for logging.
 
 Getting started files.
 
+

--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ Property files used for logging.
 
 Getting started files.
 
-
-QWERTY

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ Property files used for logging.
 
 Getting started files.
 
+
+QWERT

--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ Property files used for logging.
 
 Getting started files.
 
-
-QWERT

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ Property files used for logging.
 ### tutorial
 
 Getting started files.
+
+
+QWERTY


### PR DESCRIPTION
Pull request required to fix the following issues and also code refactoring:

-  Irregular behavior when the Start of the entry is dragged after the end and then go back as before start date. [video](https://github.com/dlemmermann/CalendarFX/files/2371680/Wierd.behavior.when.the.Start.of.the.entry.is.dragged.zip)
-  Fix behavior when the cursor is out of the dayView, now only affects the Time on the date that the entry is currently positioned.
- Fix for Multi-selection in day Page. [(697a8de)](https://github.com/dlemmermann/CalendarFX/pull/37/commits/697a8dee1555518090a4ed2334734bca3852d03e)