### PR TITLE
FIX: pom.xml controlsfx was with Snapshot version

### DIFF
--- a/CalendarFXView/pom.xml
+++ b/CalendarFXView/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
-            <version>9.0.1-SNAPSHOT</version>
+            <version>9.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I 've fixed the Build in master-11 Branch. The controlsfx was using a Snapshot Version. I 've tested the View with a custom Sample.

![image](https://user-images.githubusercontent.com/6017066/48174317-d3a6cb80-e307-11e8-88be-2a7be194a9c5.png)
