### PR TITLE
Improve start-up performance

### DIFF
--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/CalendarViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/CalendarViewSkin.java
@@ -385,7 +385,7 @@ public class CalendarViewSkin extends SkinBase<CalendarView> {
             getChildren().add(borderPane);
         }
 
-        stackPane.getChildren().setAll(dayPage, weekPage, monthPage, yearPage);
+        stackPane.getChildren().setAll(dayPage);
 
         final PageBase selectedPage = view.getSelectedPage();
         selectedPage.toFront();

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/page/YearPageSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/page/YearPageSkin.java
@@ -47,7 +47,7 @@ public class YearPageSkin extends PageBaseSkin<YearPage> {
                 sheetView.setManaged(true);
                 sheetView.setVisible(true);
                 if(!stackPane.getChildren().contains(sheetView)) {
-                    stackPane.getChildren().setAll(sheetView);
+                    stackPane.getChildren().add(sheetView);
                 }
                 break;
             case GRID:
@@ -56,7 +56,7 @@ public class YearPageSkin extends PageBaseSkin<YearPage> {
                 sheetView.setManaged(false);
                 sheetView.setVisible(false);
                 if(!stackPane.getChildren().contains(yearView)) {
-                    stackPane.getChildren().setAll(yearView);
+                    stackPane.getChildren().add(yearView);
                 }
                 break;
         }

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/page/YearPageSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/page/YearPageSkin.java
@@ -28,6 +28,7 @@ public class YearPageSkin extends PageBaseSkin<YearPage> {
 
     private YearView yearView;
     private MonthSheetView sheetView;
+    private StackPane stackPane;
 
     public YearPageSkin(YearPage view) {
         super(view);
@@ -45,12 +46,18 @@ public class YearPageSkin extends PageBaseSkin<YearPage> {
                 yearView.setVisible(false);
                 sheetView.setManaged(true);
                 sheetView.setVisible(true);
+                if(!stackPane.getChildren().contains(sheetView)) {
+                    stackPane.getChildren().setAll(sheetView);
+                }
                 break;
             case GRID:
                 yearView.setManaged(true);
                 yearView.setVisible(true);
                 sheetView.setManaged(false);
                 sheetView.setVisible(false);
+                if(!stackPane.getChildren().contains(yearView)) {
+                    stackPane.getChildren().setAll(yearView);
+                }
                 break;
         }
     }
@@ -70,15 +77,13 @@ public class YearPageSkin extends PageBaseSkin<YearPage> {
 
     @Override
     protected Node createContent() {
-        StackPane stackPane = new StackPane();
+        stackPane = new StackPane();
 
         this.sheetView = getSkinnable().getMonthSheetView();
         this.sheetView.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
 
         this.yearView = getSkinnable().getYearView();
         this.yearView.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
-
-        stackPane.getChildren().addAll(yearView, sheetView);
 
         return stackPane;
     }


### PR DESCRIPTION
Adding the pages to the Scene Graph the first time they are accessed instead when initializing the CalendarView improves the start-up time significantly, especially if a stage contains multiple instances of the CalendarView. Only the day page must be added at startup because it's the default page.

In my case there is a stage with a TabPane that contains multiple CalendarView instances. Without this change the application freezes for about 10-20 seconds until the window is shown. With this change the window is already shown after less than one second.

The only noticeable drawback of this change is a minimal delay (~1-2 seconds) when switching to the sheet view in the year page for the first time. 