### PR TITLE
Fix StringIndexOutOfBoundsException

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
@@ -168,7 +168,7 @@ public class Calendar implements EventTarget {
         setName(name);
 
         if (name != null) {
-            setShortName(name.substring(0, 1));
+            setShortName(!name.isEmpty() ? name.substring(0, 1) : "");
         }
     }
 


### PR DESCRIPTION
I'm not completely sure what the expected behaviour should be but currently a `StringIndexOutOfBoundsException` is thrown if  `name` is an empty string. I changed it to return an empty string instead of calling `substring(0,1)` if  `name` is empty. But maybe it should be `null` instead of `""`.

Also the name of the calendar will be `null` if `name` is null. But the short name will keep its initial value `Unt.`. I think it would be more consistent if either both names will be null when `name` is empty or both should keep their initial value.