### PR TITLE
Use the first visible and not read-only calendar as default

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
@@ -209,21 +209,24 @@ public abstract class DateControl extends CalendarFXControl {
         setEntryDetailsPopOverContentCallback(param -> new EntryPopOverContentPane(param.getPopOver(), param.getDateControl(), param.getEntry()));
 
         /*
-         * The default calendar provider returns the first calendar from the
-         * first source.
+         * The default calendar provider returns the first calendar which is visible and not read-only.
          */
         setDefaultCalendarProvider(control -> {
             List<CalendarSource> sources = getCalendarSources();
-            if (sources != null && !sources.isEmpty()) {
-                CalendarSource s = sources.get(0);
-                List<? extends Calendar> calendars = s.getCalendars();
-                if (calendars != null && !calendars.isEmpty()) {
-                    for (Calendar c : calendars) {
-                        if (!c.isReadOnly() && isCalendarVisible(c)) {
-                            return c;
+            if (sources != null) {
+                boolean calendarsDefined = false;
+                for (CalendarSource s : sources) {
+                    List<? extends com.calendarfx.model.Calendar> calendars = s.getCalendars();
+                    if (calendars != null && !calendars.isEmpty()) {
+                        calendarsDefined = true;
+                        for (com.calendarfx.model.Calendar c : calendars) {
+                            if (!c.isReadOnly() && isCalendarVisible(c)) {
+                                return c;
+                            }
                         }
                     }
-
+                }
+                if (calendarsDefined) {
                     Alert alert = new Alert(AlertType.WARNING);
                     alert.setTitle(Messages.getString("DateControl.TITLE_CALENDAR_PROBLEM")); //$NON-NLS-1$
                     alert.setHeaderText(Messages.getString("DateControl.HEADER_TEXT_UNABLE_TO_CREATE_NEW_ENTRY")); //$NON-NLS-1$

--- a/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
@@ -216,10 +216,10 @@ public abstract class DateControl extends CalendarFXControl {
             if (sources != null) {
                 boolean calendarsDefined = false;
                 for (CalendarSource s : sources) {
-                    List<? extends com.calendarfx.model.Calendar> calendars = s.getCalendars();
+                    List<? extends Calendar> calendars = s.getCalendars();
                     if (calendars != null && !calendars.isEmpty()) {
                         calendarsDefined = true;
-                        for (com.calendarfx.model.Calendar c : calendars) {
+                        for (Calendar c : calendars) {
                             if (!c.isReadOnly() && isCalendarVisible(c)) {
                                 return c;
                             }


### PR DESCRIPTION
Fixes #66 

Instead of just checking the first calendar of the first calendar source and disabling the context menu if this calendar is not visible and/or read-only, check all calendars and use the first one which is visible and not read-only. Only if no calendar is visible and not read-only, disable the context menu as before.