### PR TITLE
Migrate to iCal4j 4

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
@@ -31,13 +31,13 @@ import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import net.fortuna.ical4j.model.Recur;
 
-import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -353,7 +353,7 @@ public class Calendar implements EventTarget {
                         addEntryToResult(result, recurrence, startDate, endDate);
                     }
 
-                } catch (ParseException e) {
+                } catch (IllegalArgumentException | DateTimeParseException e) {
                     e.printStackTrace();
                 }
             } else {

--- a/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Calendar.java
@@ -29,8 +29,6 @@ import javafx.event.Event;
 import javafx.event.EventDispatchChain;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
-import net.fortuna.ical4j.model.Date;
-import net.fortuna.ical4j.model.DateList;
 import net.fortuna.ical4j.model.Recur;
 
 import java.text.ParseException;
@@ -54,7 +52,6 @@ import static com.calendarfx.util.LoggingDomain.MODEL;
 import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
-import static net.fortuna.ical4j.model.parameter.Value.DATE;
 
 /**
  * A calendar is responsible for storing calendar entries. It provides methods
@@ -311,60 +308,53 @@ public class Calendar implements EventTarget {
         for (Entry<?> entry : intersectingEntries) {
 
             if (entry.isRecurring()) {
-
-                /*
-                 * The recurring entry / entries.
-                 */
                 String recurrenceRule = entry.getRecurrenceRule().replaceFirst("^RRULE:", "");
-                if (recurrenceRule != null && !recurrenceRule.trim().equals("")) {
 
-                    Date utilStartDate = new Date(Date.from(entry.getStartAsZonedDateTime().toInstant()));
+                LocalDate utilStartDate = entry.getStartDate();
 
-                    try {
-                        Date utilEndDate = new Date(Date.from(et.toInstant()));
+                try {
+                    LocalDate utilEndDate = et.toLocalDate();
 
-                        /*
-                         * TODO: for performance reasons we should definitely
-                         * use the advanceTo() call, but unfortunately this
-                         * collides with the fact that e.g. the DetailedWeekView loads
-                         * data day by day. So a given day would not show
-                         * entries that start on the day before but intersect
-                         * with the given day. We have to find a solution for
-                         * this.
-                         */
-                        // iterator.advanceTo(st.toLocalDate());
+                    /*
+                     * TODO: for performance reasons we should definitely
+                     * use the advanceTo() call, but unfortunately this
+                     * collides with the fact that e.g. the DetailedWeekView loads
+                     * data day by day. So a given day would not show
+                     * entries that start on the day before but intersect
+                     * with the given day. We have to find a solution for
+                     * this.
+                     */
+                    // iterator.advanceTo(st.toLocalDate());
 
-                        DateList dateList = new Recur(recurrenceRule.replaceFirst("^RRULE:", "")).getDates(utilStartDate, utilEndDate, DATE);
+                    List<LocalDate> dateList = new Recur(recurrenceRule).getDates(utilStartDate, utilEndDate);
 
-                        for (Date date : dateList) {
-                            LocalDate repeatingDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-                            ZonedDateTime zonedDateTime = ZonedDateTime.of(repeatingDate, LocalTime.MIN, zoneId);
+                    for (LocalDate repeatingDate : dateList) {
+                        ZonedDateTime zonedDateTime = ZonedDateTime.of(repeatingDate, LocalTime.MIN, zoneId);
 
-                            Entry recurrence = entry.createRecurrence();
-                            recurrence.setId(entry.getId());
-                            recurrence.getProperties().put("com.calendarfx.recurrence.source", entry);
-                            recurrence.getProperties().put("com.calendarfx.recurrence.id", zonedDateTime.toString());
-                            recurrence.setRecurrenceRule(entry.getRecurrenceRule());
+                        Entry recurrence = entry.createRecurrence();
+                        recurrence.setId(entry.getId());
+                        recurrence.getProperties().put("com.calendarfx.recurrence.source", entry);
+                        recurrence.getProperties().put("com.calendarfx.recurrence.id", zonedDateTime.toString());
+                        recurrence.setRecurrenceRule(entry.getRecurrenceRule());
 
-                            LocalDate recurrenceStartDate = zonedDateTime.toLocalDate();
-                            LocalDate recurrenceEndDate = recurrenceStartDate.plus(entry.getStartDate().until(entry.getEndDate()));
+                        LocalDate recurrenceStartDate = zonedDateTime.toLocalDate();
+                        LocalDate recurrenceEndDate = recurrenceStartDate.plus(entry.getStartDate().until(entry.getEndDate()));
 
-                            Interval recurrenceInterval = entry.getInterval().withDates(recurrenceStartDate, recurrenceEndDate);
+                        Interval recurrenceInterval = entry.getInterval().withDates(recurrenceStartDate, recurrenceEndDate);
 
-                            recurrence.setInterval(recurrenceInterval);
-                            recurrence.setUserObject(entry.getUserObject());
-                            recurrence.setTitle(entry.getTitle());
-                            recurrence.setMinimumDuration(entry.getMinimumDuration());
-                            recurrence.setFullDay(entry.isFullDay());
-                            recurrence.setLocation(entry.getLocation());
-                            recurrence.setCalendar(this);
+                        recurrence.setInterval(recurrenceInterval);
+                        recurrence.setUserObject(entry.getUserObject());
+                        recurrence.setTitle(entry.getTitle());
+                        recurrence.setMinimumDuration(entry.getMinimumDuration());
+                        recurrence.setFullDay(entry.isFullDay());
+                        recurrence.setLocation(entry.getLocation());
+                        recurrence.setCalendar(this);
 
-                            addEntryToResult(result, recurrence, startDate, endDate);
-                        }
-
-                    } catch (ParseException e) {
-                        e.printStackTrace();
+                        addEntryToResult(result, recurrence, startDate, endDate);
                     }
+
+                } catch (ParseException e) {
+                    e.printStackTrace();
                 }
             } else {
                 addEntryToResult(result, entry, startDate, endDate);

--- a/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
@@ -37,13 +37,13 @@ import javafx.collections.ObservableMap;
 import net.fortuna.ical4j.model.Recur;
 import org.controlsfx.control.PropertySheet.Item;
 
-import java.text.ParseException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -693,7 +693,7 @@ public class Entry<T> implements Comparable<Entry<?>> {
                         try {
                             Recur<LocalDate> recur = new Recur<>(newRecurrence.replaceFirst("^RRULE:", ""));
                             setRecurrenceEnd(Objects.requireNonNullElse(recur.getUntil(), LocalDate.MAX));
-                        } catch (ParseException e) {
+                        } catch (IllegalArgumentException | DateTimeParseException e) {
                             e.printStackTrace();
                         }
                     } else {
@@ -1520,7 +1520,7 @@ public class Entry<T> implements Comparable<Entry<?>> {
                     return true;
                 }
             }
-        } catch (ParseException ex) {
+        } catch (IllegalArgumentException | DateTimeParseException ex) {
             ex.printStackTrace();
         }
 

--- a/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/model/Entry.java
@@ -34,10 +34,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
-import net.fortuna.ical4j.model.Date;
-import net.fortuna.ical4j.model.DateList;
 import net.fortuna.ical4j.model.Recur;
-import net.fortuna.ical4j.model.parameter.Value;
 import org.controlsfx.control.PropertySheet.Item;
 
 import java.text.ParseException;
@@ -48,6 +45,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -640,7 +638,7 @@ public class Entry<T> implements Comparable<Entry<?>> {
      * @see #recurrenceRuleProperty()
      */
     public final boolean isRecurring() {
-        return recurrenceRule != null && !(recurrenceRule.get() == null) && !recurrenceRule.get().trim().equals("");
+        return recurrenceRule != null && !(recurrenceRule.get() == null) && !recurrenceRule.get().isBlank();
     }
 
     /*
@@ -693,13 +691,8 @@ public class Entry<T> implements Comparable<Entry<?>> {
                 private void updateRecurrenceEndProperty(String newRecurrence) {
                     if (newRecurrence != null && !newRecurrence.trim().equals("")) {
                         try {
-                            Recur recur = new Recur(newRecurrence.replaceFirst("^RRULE:", ""));
-                            Date until = recur.getUntil();
-                            if (until != null) {
-                                setRecurrenceEnd(until.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
-                            } else {
-                                setRecurrenceEnd(LocalDate.MAX);
-                            }
+                            Recur<LocalDate> recur = new Recur<>(newRecurrence.replaceFirst("^RRULE:", ""));
+                            setRecurrenceEnd(Objects.requireNonNullElse(recur.getUntil(), LocalDate.MAX));
                         } catch (ParseException e) {
                             e.printStackTrace();
                         }
@@ -1499,12 +1492,12 @@ public class Entry<T> implements Comparable<Entry<?>> {
     }
 
     private boolean isRecurrenceShowing(Entry<?> entry, ZonedDateTime st, ZonedDateTime et, ZoneId zoneId) {
-        String recurrenceRule = entry.getRecurrenceRule();
+        String recurrenceRule = entry.getRecurrenceRule().replaceFirst("^RRULE:", "");
 
-        Date utilStartDate = new Date(Date.from(entry.getStartAsZonedDateTime().toInstant()));
+        LocalDate utilStartDate = entry.getStartDate();
 
         try {
-            Date utilEndDate = new Date(Date.from(et.toInstant()));
+            LocalDate utilEndDate = et.toLocalDate();
 
             /*
              * TODO: for performance reasons we should definitely
@@ -1517,10 +1510,9 @@ public class Entry<T> implements Comparable<Entry<?>> {
              */
             // iterator.advanceTo(st.toLocalDate());
 
-            DateList dateList = new Recur(recurrenceRule.replaceFirst("^RRULE:", "")).getDates(utilStartDate, utilEndDate, Value.DATE);
+            List<LocalDate> dateList = new Recur<LocalDate>(recurrenceRule).getDates(utilStartDate, utilEndDate);
 
-            for (Date date : dateList) {
-                LocalDate repeatingDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            for (LocalDate repeatingDate : dateList) {
                 ZonedDateTime recurrenceStart = ZonedDateTime.of(repeatingDate, LocalTime.MIN, zoneId);
                 ZonedDateTime recurrenceEnd = recurrenceStart.plus(entry.getDuration());
 

--- a/CalendarFXView/src/main/java/com/calendarfx/util/Util.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/util/Util.java
@@ -33,10 +33,10 @@ import net.fortuna.ical4j.model.Recur.Frequency;
 
 import java.lang.ref.WeakReference;
 import java.text.MessageFormat;
-import java.text.ParseException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 import java.util.Objects;
 
@@ -181,7 +181,7 @@ public class Util {
             }
 
             return sb.toString();
-        } catch (ParseException e) {
+        } catch (IllegalArgumentException | DateTimeParseException e) {
             e.printStackTrace();
             return Messages.getString("Util.INVALID_RULE");
         }

--- a/CalendarFXView/src/main/java/com/calendarfx/util/Util.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/util/Util.java
@@ -26,7 +26,6 @@ import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.ScrollBar;
-import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.WeekDay;
 import net.fortuna.ical4j.model.WeekDayList;
@@ -37,7 +36,6 @@ import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Objects;
@@ -75,7 +73,7 @@ public class Util {
                                               LocalDate startDate) {
 
         try {
-            Recur rule = new Recur(rrule.replaceFirst("^RRULE:", ""));
+            Recur<LocalDate> rule = new Recur<>(rrule.replaceFirst("^RRULE:", ""));
             StringBuilder sb = new StringBuilder();
 
             String granularity = "";
@@ -172,14 +170,13 @@ public class Util {
                     sb.append(MessageFormat.format(Messages.getString("Util.TIMES"), count));
                 }
             } else {
-                Date until = rule.getUntil();
+                LocalDate until = rule.getUntil();
                 if (until != null) {
-                    LocalDate localDate = until.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
                     sb.append(
                             MessageFormat.format(Messages.getString("Util.UNTIL_DATE"),
                                     DateTimeFormatter
                                             .ofLocalizedDate(FormatStyle.LONG)
-                                            .format(localDate)));
+                                            .format(until)));
                 }
             }
 

--- a/CalendarFXView/src/main/java/com/calendarfx/view/RecurrenceView.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/RecurrenceView.java
@@ -28,8 +28,8 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.control.Skin;
 import net.fortuna.ical4j.model.Recur;
 
-import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -104,7 +104,7 @@ public class RecurrenceView extends CalendarFXControl {
                     new Recur(newValue.replaceFirst("^RRULE:", ""));
                 }
                 super.set(newValue);
-            } catch (ParseException e) {
+            } catch (IllegalArgumentException | DateTimeParseException e) {
                 e.printStackTrace();
             }
         }

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/RecurrenceViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/RecurrenceViewSkin.java
@@ -36,14 +36,11 @@ import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.util.StringConverter;
-import net.fortuna.ical4j.model.Date;
-import net.fortuna.ical4j.model.DateList;
 import net.fortuna.ical4j.model.NumberList;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.WeekDay;
 import net.fortuna.ical4j.model.WeekDayList;
 import net.fortuna.ical4j.model.WeekDay.Day;
-import net.fortuna.ical4j.model.parameter.Value;
 
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -52,6 +49,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.List;
 import java.util.logging.Level;
 
 import static javafx.scene.layout.Region.USE_COMPUTED_SIZE;
@@ -311,7 +309,7 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
             if (rule == null) {
                 return;
             }
-            Recur rrule = new Recur(rule.replaceFirst("^RRULE:", ""));
+            Recur<LocalDate> rrule = new Recur<>(rule.replaceFirst("^RRULE:", ""));
             switch (rrule.getFrequency()) {
                 case DAILY:
                     frequencyBox.setValue(Frequency.DAILY);
@@ -340,11 +338,10 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
 
             }
 
-            Date until = rrule.getUntil();
+            LocalDate until = rrule.getUntil();
             if (until != null) {
                 endsOnButton.setSelected(true);
-                endsOnDatePicker.setValue(
-                        until.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+                endsOnDatePicker.setValue(until);
             } else if (rrule.getCount() > 0) {
                 endsAfterButton.setSelected(true);
             } else {
@@ -392,7 +389,7 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
     }
 
     private void updateRule() {
-        Recur.Builder rBuilder = new Recur.Builder();
+        Recur.Builder<LocalDate> rBuilder = new Recur.Builder<>();
         switch (frequencyBox.getValue()) {
             case DAILY:
                 rBuilder.frequency(net.fortuna.ical4j.model.Recur.Frequency.DAILY);
@@ -419,7 +416,7 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
 
         if (endsOnButton.isSelected()) {
             LocalDate date = endsOnDatePicker.getValue();
-            rBuilder.until(new Date(Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant())));
+            rBuilder.until(date);
         }
 
         if (endsAfterButton.isSelected()) {
@@ -502,18 +499,17 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
             rBuilder.dayList(weekdays);
         }
 
-        Recur rule = rBuilder.build();
+        Recur<LocalDate> rule = rBuilder.build();
         getSkinnable().setRecurrenceRule(rule.toString());
 
         if (LoggingDomain.RECURRENCE.isLoggable(Level.FINE)) {
             LoggingDomain.RECURRENCE.fine(
                     "test dumping 10 recurrences starting with today's date");
 
-            Date today = new Date(Date.from(LocalDate.of(2015, 8, 18).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-            DateList dates = rule.getDates(today, today, new Date(Long.MAX_VALUE), Value.DATE, 10);
+            LocalDate today = LocalDate.of(2015, 8, 18);
+            List<LocalDate> dates = rule.getDates(today, today, LocalDate.MAX, 10);
 
-            for (Date date : dates) {
-                LocalDate repeatingDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            for (LocalDate repeatingDate : dates) {
                 LoggingDomain.RECURRENCE.fine(repeatingDate.toString());
             }
         }

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/RecurrenceViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/RecurrenceViewSkin.java
@@ -42,12 +42,12 @@ import net.fortuna.ical4j.model.WeekDay;
 import net.fortuna.ical4j.model.WeekDayList;
 import net.fortuna.ical4j.model.WeekDay.Day;
 
-import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 import java.util.List;
 import java.util.logging.Level;
@@ -369,7 +369,7 @@ public class RecurrenceViewSkin extends SkinBase<RecurrenceView> {
 
             summary.setText(Util.convertRFC2445ToText(rule,
                     getSkinnable().getStartDate()));
-        } catch (ParseException e) {
+        } catch (IllegalArgumentException | DateTimeParseException e) {
             e.printStackTrace();
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <javafx.version>14</javafx.version>
         <javafx.maven.plugin.version>0.0.4</javafx.maven.plugin.version>
         <controlsfx.version>11.0.1</controlsfx.version>
-        <ical4j.version>3.0.15</ical4j.version>
+        <ical4j.version>4.0.0-alpha1</ical4j.version>
         <ikonli.version>11.3.5</ikonli.version>
     </properties>
 
@@ -71,6 +71,16 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <net.fortuna.ical4j.timezone.cache.impl>net.fortuna.ical4j.util.MapTimeZoneCache</net.fortuna.ical4j.timezone.cache.impl>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <javafx.version>14</javafx.version>
         <javafx.maven.plugin.version>0.0.4</javafx.maven.plugin.version>
         <controlsfx.version>11.0.1</controlsfx.version>
-        <ical4j.version>4.0.0-alpha1</ical4j.version>
+        <ical4j.version>4.0.0-alpha2</ical4j.version>
         <ikonli.version>11.3.5</ikonli.version>
     </properties>
 


### PR DESCRIPTION
This is my initial work on migrating to the iCal4j 4 API supporting the new Java date/time API. See [iCal4j 4 and the new Java date/time API](https://ical4j.github.io/2019/06/18/ical4j-4-preview.html).

I currently use the first alpha release, which has still bugs and is not stable jet. See [iCal4j 4 Alpha Release](https://ical4j.github.io/2020/02/28/ical4j-4-alpha.html).

The main App seems to work fine, but I experience issues with the iCalApp, even without this patch. I'll look into that.

What do you think?