### PR TITLE
Alternative layout mode for calendar entries: segments.

### DIFF
--- a/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
+++ b/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
@@ -21,13 +21,17 @@ import com.calendarfx.model.Calendar.Style;
 import com.calendarfx.model.CalendarSource;
 import com.calendarfx.model.Entry;
 import com.calendarfx.model.Marker;
-import com.calendarfx.view.DayEntryView;
 import com.calendarfx.view.DayView;
 import com.calendarfx.view.ResourceCalendarView;
+import com.calendarfx.view.segments.SegmentedDayEntryView;
+import com.calendarfx.view.segments.basic.AlignedEntrySegment;
+import com.calendarfx.view.segments.basic.EntrySegment;
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
 import javafx.scene.Scene;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
@@ -35,6 +39,7 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import org.kordamp.ikonli.fontawesome.FontAwesome;
 import org.kordamp.ikonli.javafx.FontIcon;
@@ -42,6 +47,8 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public class ResourceCalendarApp extends Application {
 
@@ -116,7 +123,29 @@ public class ResourceCalendarApp extends Application {
              */
             dayView.setEntryViewFactory(entry -> {
 
-                DayEntryView entryView = new DayEntryView(entry);
+                SegmentedDayEntryView entryView = new SegmentedDayEntryView(entry);
+
+                /* Some additional visual elements to quickly demonstrate how segments API works.
+                 *
+                 * Description (weight: 5) is less important than footer (weight: 8).
+                 *
+                 * Additionally we add some simple graphical representation of entry status (without logic),
+                 * here in a form of three centered rectangles (weight: 6).
+                 * To place it before description segment we set the order to -1.
+                 *
+                 * All of additional segments are less important than title (weight: 10) and start time (weight: 9).
+                 * Title and start time segments are created by default (this can be override).
+                 *
+                 * Depending on how much space is available some segments can be hidden to free space for more
+                 * important ones - in other words: entries with less that required available space will not show
+                 * all segments.
+                 */
+                entryView.addSegment(new EntrySegment(5, VPos.CENTER,
+                        createLabel("#description: some additional information")));
+                entryView.addSegment(new EntrySegment(8, VPos.BOTTOM,
+                        createLabel("#footer")));
+                entryView.addSegment(new AlignedEntrySegment(6, VPos.CENTER, -1,
+                        createStatusRectangles()));
 
                 /* PSI:
                  * Here you can experiment with the new alignment strategy that allows
@@ -215,6 +244,29 @@ public class ResourceCalendarApp extends Application {
         primaryStage.setHeight(1000);
         primaryStage.centerOnScreen();
         primaryStage.show();
+    }
+
+    private Label createLabel(String text) {
+        Label label = new Label(text);
+        label.setMouseTransparent(true);
+        label.setWrapText(true);
+        return label;
+    }
+
+    private List<AlignedEntrySegment.AlignedNode> createStatusRectangles() {
+        return Arrays.asList(
+            new AlignedEntrySegment.AlignedNode(createRectangle(10, Color.GREEN), HPos.CENTER),
+            new AlignedEntrySegment.AlignedNode(createRectangle(10, Color.YELLOW), HPos.CENTER),
+            new AlignedEntrySegment.AlignedNode(createRectangle(10, Color.RED), HPos.CENTER)
+        );
+    }
+
+    private Rectangle createRectangle(double size, Color color) {
+        Rectangle rectangle = new Rectangle();
+        rectangle.setWidth(size);
+        rectangle.setHeight(size);
+        rectangle.setFill(color);
+        return rectangle;
     }
 
     class HelloDayViewCalendar extends Calendar {

--- a/CalendarFXView/src/main/java/com/calendarfx/util/ViewHelper.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/util/ViewHelper.java
@@ -16,9 +16,13 @@
 
 package com.calendarfx.util;
 
+import com.calendarfx.model.Calendar;
+import com.calendarfx.model.Entry;
 import com.calendarfx.view.DateControl;
 import com.calendarfx.view.DayViewBase;
 import com.calendarfx.view.DayViewBase.EarlyLateHoursStrategy;
+import com.calendarfx.view.DraggedEntry;
+import com.calendarfx.view.EntryViewBase;
 import impl.com.calendarfx.view.DayViewScrollPane;
 import javafx.collections.ObservableList;
 import javafx.geometry.Bounds;
@@ -269,5 +273,21 @@ public final class ViewHelper {
         if (requestedTime != null) {
             scrollPane.scrollToTime(requestedTime);
         }
+    }
+
+    public static Entry<?> getEntry(EntryViewBase<?> entryView) {
+        final Entry<?> entry = entryView.getEntry();
+        if (entry.isRecurrence()) {
+            return entry.getRecurrenceSourceEntry();
+        }
+        return entry;
+    }
+
+    public static Calendar getCalendar(EntryViewBase<?> entryView) {
+        final Entry<?> entry = getEntry(entryView);
+        if (entry instanceof DraggedEntry) {
+            return ((DraggedEntry) entry).getOriginalCalendar();
+        }
+        return entry.getCalendar();
     }
 }

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/SegmentedDayEntryView.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/SegmentedDayEntryView.java
@@ -1,0 +1,91 @@
+package com.calendarfx.view.segments;
+
+import com.calendarfx.model.Entry;
+import com.calendarfx.view.DayEntryView;
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import com.calendarfx.view.segments.basic.AlignedEntrySegment;
+import com.calendarfx.view.segments.basic.AlignedEntrySegment.AlignedNode;
+import com.calendarfx.view.segments.traits.SegmentedEntryViewTrait;
+import impl.com.calendarfx.view.segments.SegmentedDayEntryViewSkin;
+import impl.com.calendarfx.view.segments.SegmentedEntryViewSkin;
+import javafx.beans.property.ReadOnlyListWrapper;
+import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.control.Skin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Extended "bridge" implementation of {@link DayEntryView} that allows to use the visibility control functionality of
+ * {@link SegmentedEntryViewSkin}.
+ */
+public class SegmentedDayEntryView extends DayEntryView implements SegmentedEntryViewTrait {
+
+    public static final int DEFAULT_POSITIONAL_SEGMENTS_VISIBILITY_WEIGHT = SegmentedEntryViewSkin.DEFAULT_VISIBILITY_WEIGHT_THRESHOLD - 1;
+
+    private final ReadOnlyListWrapper<EntrySegmentBase> segments = new ReadOnlyListWrapper<>(this, "segments");
+
+    private List<EntrySegmentBase> positionalSegments;
+
+    /**
+     * Constructs a new entry view for the given calendar entry.
+     *
+     * @param entry the entry for which the view will be created
+     */
+    public SegmentedDayEntryView(Entry<?> entry) {
+        super(entry);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        assignNodesToSegments();
+        return new SegmentedDayEntryViewSkin(this);
+    }
+
+    protected void assignNodesToSegments()
+    {
+        if (positionalSegments != null) {
+            positionalSegments.forEach(this::removeSegment);
+        }
+        positionalSegments = asPositionalSegments(getNodes());
+        positionalSegments.forEach(this::addSegment);
+    }
+
+    private List<EntrySegmentBase> asPositionalSegments(Map<Pos, List<Node>> positionalNodes )
+    {
+        return groupByVPos(positionalNodes).entrySet()
+            .stream()
+            .map(this::asPositionalSegment)
+            .collect(Collectors.toList());
+    }
+
+    private EntrySegmentBase asPositionalSegment(Map.Entry<VPos, List<AlignedNode>> group) {
+        return new AlignedEntrySegment(getPositionalSegmentsVisibilityWeight(), group.getKey(), EntrySegmentBase.DEFAULT_ORDER, group.getValue());
+    }
+
+    public int getPositionalSegmentsVisibilityWeight() {
+        return DEFAULT_POSITIONAL_SEGMENTS_VISIBILITY_WEIGHT;
+    }
+
+    private Map<VPos, List<AlignedNode>> groupByVPos(Map<Pos, List<Node>> aPositionalNodes) {
+        final Map<VPos, List<AlignedNode>> groupedNodes = new HashMap<>();
+        for (Map.Entry<Pos, List<Node>> entry : aPositionalNodes.entrySet()) {
+            final Pos pos = entry.getKey();
+            for (Node node : entry.getValue()) {
+                groupedNodes.computeIfAbsent(pos.getVpos(), key -> new ArrayList<>()).add(new AlignedNode(node, pos.getHpos()));
+            }
+        }
+        return groupedNodes;
+    }
+
+    @Override
+    public ReadOnlyListWrapper<EntrySegmentBase> segmentsProperty() {
+        return segments;
+    }
+
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/SegmentedEntryView.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/SegmentedEntryView.java
@@ -1,0 +1,41 @@
+package com.calendarfx.view.segments;
+
+import com.calendarfx.model.Entry;
+import com.calendarfx.view.DateControl;
+import com.calendarfx.view.DayEntryView;
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import com.calendarfx.view.segments.traits.SegmentedEntryViewTrait;
+import impl.com.calendarfx.view.segments.SegmentedEntryViewSkin;
+import javafx.beans.property.ReadOnlyListWrapper;
+import javafx.scene.control.Skin;
+
+/**
+ * Implementation of {@link EntryViewBase} that uses {@link SegmentedEntryViewSkin} as default layout and
+ * provides data for it. Alternative implementation for {@link DayEntryView}, which gives more control on what
+ * is visible when there is not enough space to display all visual elements of an calendar entry.
+ */
+public class SegmentedEntryView<T extends DateControl> extends EntryViewBase<T> implements SegmentedEntryViewTrait {
+
+    private final ReadOnlyListWrapper<EntrySegmentBase> segments = new ReadOnlyListWrapper<>(this, "segments");
+
+    /**
+     * Constructs a new view for the given entry.
+     *
+     * @param entry the calendar entry
+     */
+    public SegmentedEntryView(Entry<?> entry) {
+        super(entry);
+    }
+
+    @Override
+    public ReadOnlyListWrapper<EntrySegmentBase> segmentsProperty() {
+        return segments;
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new SegmentedEntryViewSkin<>(this);
+    }
+
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/base/EntrySegmentBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/base/EntrySegmentBase.java
@@ -1,0 +1,75 @@
+package com.calendarfx.view.segments.base;
+
+import impl.com.calendarfx.view.segments.SegmentedEntryViewSkin;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.control.Skin;
+import javafx.scene.layout.Region;
+
+/**
+ * Base class defining common interface for creating entry segments used by {@link SegmentedEntryViewSkin}.
+ * Beside typical {@link Node}, it contains meta-information about importance of contained node. Can be used
+ * by the implementation of {@link Skin} to control visibility of contained nodes.
+ */
+public abstract class EntrySegmentBase
+{
+    // default value of order field used when order is not explicitly defined
+    public static final int DEFAULT_ORDER = 0;
+
+    private final int visibilityWeight;
+    private final VPos alignment;
+    private final int order;
+
+    public EntrySegmentBase(int visibilityWeight, VPos alignment, int order) {
+        this.visibilityWeight = visibilityWeight;
+        this.alignment = alignment;
+        this.order = order;
+    }
+
+    /**
+     * Returns contained node.
+     *
+     * @return node
+     */
+    public abstract Node getNode();
+
+    /**
+     * Requests a try of adjusting contents layout to fit requested bounds.
+     * @param region region
+     * @param contentWidth maximum usable width
+     * @param contentHeight maximum usable height
+     */
+    public abstract void prepareLayout(final Region region, final double contentWidth, final double contentHeight);
+
+    /**
+     * Returns visibility weight, segments with higher visibility weight will have higher priority to stay visible
+     * when there is not enough space to display all segments.
+     *
+     * @return visibility weight
+     */
+    public int getVisibilityWeight()
+    {
+        return visibilityWeight;
+    }
+
+    /**
+     * Tells in which of three sections of the entry should the segment be positioned: top, center or bottom/baseline.
+     *
+     * @return vertical alignment of the segment
+     */
+    public VPos getAlignment()
+    {
+        return alignment;
+    }
+
+    /**
+     * Order value is used for sorting segments, segments with lower order value will be measured and
+     * positioned before segments with higher value. Order works the same for all possible alignments -
+     * segments with lower order are positioned higher than ones with lower value.
+     *
+     * @return order
+     */
+    public int getOrder() {
+        return order;
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/base/LabelSegmentBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/base/LabelSegmentBase.java
@@ -1,0 +1,72 @@
+package com.calendarfx.view.segments.base;
+
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.segments.basic.EntrySegment;
+import com.calendarfx.view.segments.traits.ReactiveEntrySegmentTrait;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
+import javafx.geometry.VPos;
+import javafx.scene.control.Label;
+
+/**
+ * Base class for creating segment that contains single label, reacts on value changes of provided property of view entry.
+ *
+ * @param <T> type of value contained by listened property
+ */
+public abstract class LabelSegmentBase<T> extends EntrySegment implements ReactiveEntrySegmentTrait {
+
+    private final ChangeListener<T> updateListener = this::update;
+    private final WeakChangeListener<T> weakUpdateListener = new WeakChangeListener<>(updateListener);
+
+    public LabelSegmentBase(int visibilityWeight, VPos alignment, int order) {
+        this(visibilityWeight, alignment, order, new Label());
+    }
+
+    protected LabelSegmentBase(int visibilityWeight, VPos alignment, int order, Label label) {
+        super(visibilityWeight, alignment, order, label);
+        configureLabel(label);
+    }
+
+    @Override
+    public void observe(EntryViewBase<?> viewEntry) {
+        final ObservableValue<T> property = getValueProperty(viewEntry);
+        if (property != null) {
+            property.addListener(weakUpdateListener);
+            setValue(property.getValue());
+        }
+    }
+
+    /**
+     * Provides property which is listened for value changes.
+     *
+     * @param viewEntry view entry
+     * @return property which is listened for value changes
+     */
+    protected abstract ObservableValue<T> getValueProperty(EntryViewBase<?> viewEntry);
+
+    /**
+     * Configures contained label.
+     *
+     * @param label label
+     */
+    protected void configureLabel(Label label) {}
+
+    /**
+     * Formats value before is set as a text in contained label.
+     *
+     * @param value value
+     * @return formatted value as string
+     */
+    protected String formatValue(T value) {
+        return value.toString();
+    }
+
+    protected void setValue(T value) {
+        ((Label)getNode()).setText(formatValue(value));
+    }
+
+    private void update(ObservableValue<? extends T> observable, T oldValue, T newValue) {
+        setValue(newValue);
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/AlignedEntrySegment.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/AlignedEntrySegment.java
@@ -1,0 +1,96 @@
+package com.calendarfx.view.segments.basic;
+
+import javafx.geometry.HPos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Segment which allows to position nodes as three groups aligned to: left, center or right. Requires to wrap
+ * nodes in {@link AlignedNode} instance, which keeps additional alignment information. Segment does not try
+ * to prevent overlapping of contained groups, inside of group nodes are placed next to each other
+ * horizontally in order how they were provided.
+ */
+public class AlignedEntrySegment extends EntrySegment {
+
+    /**
+     * Helper class for storing node and keeping information about its alignment inside of the segment.
+     */
+    public static class AlignedNode {
+        final Node node;
+        final HPos alignment;
+
+        public AlignedNode(Node aNode, HPos aAlignment) {
+            node = aNode;
+            alignment = aAlignment;
+        }
+
+        public Node getNode() {
+            return node;
+        }
+
+        public HPos getAlignment() {
+            return alignment;
+        }
+    }
+
+    final Map<HPos, Pane> panes = new HashMap<>();
+
+    public AlignedEntrySegment(int visibilityWeight, VPos alignment, List<AlignedNode> nodes) {
+        this(visibilityWeight, alignment, DEFAULT_ORDER, new Pane(), nodes);
+    }
+
+    public AlignedEntrySegment(int visibilityWeight, VPos alignment, int order, List<AlignedNode> nodes) {
+        this(visibilityWeight, alignment, order, new Pane(), nodes);
+    }
+
+    private AlignedEntrySegment(int aVisibilityWeight, VPos alignment, int order, Pane root, List<AlignedNode> nodes) {
+        super(aVisibilityWeight, alignment, order, root);
+
+        root.setMouseTransparent(true);
+
+        nodes.forEach(entry -> panes.computeIfAbsent(entry.getAlignment(), this::providePane)
+                .getChildren()
+                .add(entry.getNode()));
+
+        root.getChildren().addAll(panes.values());
+    }
+
+    /**
+     * Provides group pane. Could be override to change how nodes are grouped.
+     *
+     * @param pos horizontal position of the pane
+     * @return pane
+     */
+    protected Pane providePane(HPos pos) {
+        return new HBox();
+    }
+
+    @Override
+    public void prepareLayout(Region region, double contentWidth, double contentHeight) {
+        super.prepareLayout(region, contentWidth, contentHeight);
+
+        final Pane l = panes.getOrDefault(HPos.LEFT, null);
+        if (l != null) {
+            l.relocate(0, 0);
+        }
+
+        final Pane c = panes.getOrDefault(HPos.CENTER, null);
+        if (c != null) {
+            final double w = c.prefWidth(contentHeight);
+            c.relocate(region.snapPositionX(contentWidth * 0.5 - w * 0.5),  0);
+        }
+
+        final Pane r = panes.getOrDefault(HPos.RIGHT, null);
+        if (r != null) {
+            final double w = r.prefWidth(contentHeight);
+            r.relocate(region.snapPositionX(contentWidth - w), 0);
+        }
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/EntrySegment.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/EntrySegment.java
@@ -1,0 +1,37 @@
+package com.calendarfx.view.segments.basic;
+
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.layout.Region;
+
+/**
+ * Most basic but complete implementation of segments base class. Can be used for displaying single nodes
+ * or groups of nodes contained in provided pane.
+ */
+public class EntrySegment extends EntrySegmentBase {
+
+    private final Node node;
+
+    public EntrySegment(int visibilityWeight, VPos alignment, Node node) {
+        super(visibilityWeight, alignment, DEFAULT_ORDER);
+        this.node = node;
+    }
+
+    public EntrySegment(int visibilityWeight, VPos alignment, int order, Node node) {
+        super(visibilityWeight, alignment, order);
+        this.node = node;
+    }
+
+    @Override
+    public Node getNode()
+    {
+        return node;
+    }
+
+    @Override
+    public void prepareLayout(Region region, double contentWidth, double contentHeight) {
+        double nodeHeight = node.prefHeight(contentWidth);
+        node.resize(region.snapSizeX(contentWidth), region.snapSizeY(nodeHeight));
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/StartTimeSegment.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/StartTimeSegment.java
@@ -1,0 +1,54 @@
+package com.calendarfx.view.segments.basic;
+
+import com.calendarfx.model.Calendar;
+import com.calendarfx.util.ViewHelper;
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.segments.base.LabelSegmentBase;
+import com.calendarfx.view.segments.traits.StyleAwareEntrySegmentTrait;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.VPos;
+import javafx.scene.control.Label;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
+/**
+ * Basic implementation of {@link LabelSegmentBase} for displaying start time of an entry. Automatically refreshes
+ * its value when underlying property of an entry is changed.
+ */
+public class StartTimeSegment extends LabelSegmentBase<LocalTime> implements StyleAwareEntrySegmentTrait {
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT);
+
+    public StartTimeSegment(int visibilityWeight, VPos alignment) {
+        super(visibilityWeight, alignment, DEFAULT_ORDER);
+    }
+
+    public StartTimeSegment(int visibilityWeight, VPos alignment, int order) {
+        super(visibilityWeight, alignment, order);
+    }
+
+    @Override
+    protected ObservableValue<LocalTime> getValueProperty(EntryViewBase<?> viewEntry) {
+        return ViewHelper.getEntry(viewEntry).startTimeProperty();
+    }
+
+    @Override
+    protected void configureLabel(Label label) {
+        label.setManaged(false);
+        label.setMouseTransparent(true);
+        label.setMinSize(0, 0);
+    }
+
+    @Override
+    protected String formatValue(LocalTime value) {
+        return formatter.format(value);
+    }
+
+    @Override
+    public void updateStyle(EntryViewBase<?> entryView) {
+        final Calendar calendar = ViewHelper.getCalendar(entryView);
+        getNode().getStyleClass().setAll("start-time-label", "default-style-entry-time-label", calendar.getStyle() + "-entry-time-label");
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/TitleSegment.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/basic/TitleSegment.java
@@ -1,0 +1,44 @@
+package com.calendarfx.view.segments.basic;
+
+import com.calendarfx.model.Calendar;
+import com.calendarfx.util.ViewHelper;
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.segments.base.LabelSegmentBase;
+import com.calendarfx.view.segments.traits.StyleAwareEntrySegmentTrait;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.VPos;
+import javafx.scene.control.Label;
+
+/**
+ * Basic implementation of {@link LabelSegmentBase} for displaying title of an entry. Automatically refreshes its
+ * value when underlying property of an entry is changed.
+ */
+public class TitleSegment extends LabelSegmentBase<String> implements StyleAwareEntrySegmentTrait {
+
+    public TitleSegment(int visibilityWeight, VPos alignment) {
+        super(visibilityWeight, alignment, DEFAULT_ORDER);
+    }
+
+    public TitleSegment(int visibilityWeight, VPos alignment, int order) {
+        super(visibilityWeight, alignment, order);
+    }
+
+    @Override
+    protected ObservableValue<String> getValueProperty(EntryViewBase<?> viewEntry) {
+        return ViewHelper.getEntry(viewEntry).titleProperty();
+    }
+
+    @Override
+    protected void configureLabel(Label label) {
+        label.setManaged(false);
+        label.setMouseTransparent(true);
+        label.setWrapText(true);
+        label.setMinSize(0, 0);
+    }
+
+    @Override
+    public void updateStyle(EntryViewBase<?> entryView) {
+        final Calendar calendar = ViewHelper.getCalendar(entryView);
+        getNode().getStyleClass().setAll("title-label", "default-style-entry-title-label", calendar.getStyle() + "-entry-title-label");
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/ReactiveEntrySegmentTrait.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/ReactiveEntrySegmentTrait.java
@@ -1,0 +1,18 @@
+package com.calendarfx.view.segments.traits;
+
+import com.calendarfx.view.EntryViewBase;
+
+/**
+ * Trait that allows segment listening to change of properties contained by view entry.
+ */
+public interface ReactiveEntrySegmentTrait {
+
+    /**
+     * Called when segment is accepted to use as part of skin. Allows adding listeners for selected properties
+     * of {@link EntryViewBase}, added listeners references should be a type of weak.
+     *
+     * @param viewEntry view entry
+     */
+    void observe(EntryViewBase<?> viewEntry);
+
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/SegmentedEntryViewTrait.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/SegmentedEntryViewTrait.java
@@ -1,0 +1,50 @@
+package com.calendarfx.view.segments.traits;
+
+import com.calendarfx.view.EntryViewBase;
+import impl.com.calendarfx.view.segments.SegmentedEntryViewSkin;
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import javafx.beans.property.ReadOnlyListWrapper;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.util.ArrayList;
+
+/**
+ * Trait that allows usage of {@link SegmentedEntryViewSkin} by any implementation of the {@link EntryViewBase}.
+ */
+public interface SegmentedEntryViewTrait {
+
+    /**
+     * Provides property which keeps collection of segments.
+     *
+     * @return segments storing property
+     */
+    ReadOnlyListWrapper<EntrySegmentBase> segmentsProperty();
+
+    default ObservableList<EntrySegmentBase> getSegments() {
+        return segmentsProperty().getReadOnlyProperty();
+    }
+
+    default void clearSegments() {
+        final ReadOnlyListWrapper<EntrySegmentBase> segments = segmentsProperty();
+        if (segments.get() != null) {
+            segments.get().clear();
+        }
+    }
+
+    default void addSegment(EntrySegmentBase segment) {
+        final ReadOnlyListWrapper<EntrySegmentBase> segments = segmentsProperty();
+        if (segments.get() == null) {
+            segments.set(FXCollections.observableList(new ArrayList<>()));
+        }
+        segments.get().add(segment);
+    }
+
+    default void removeSegment(EntrySegmentBase segment) {
+        final ReadOnlyListWrapper<EntrySegmentBase> segments = segmentsProperty();
+        if (segments.get() != null) {
+            segments.get().remove(segment);
+        }
+    }
+
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/StyleAwareEntrySegmentTrait.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/segments/traits/StyleAwareEntrySegmentTrait.java
@@ -1,0 +1,18 @@
+package com.calendarfx.view.segments.traits;
+
+import com.calendarfx.view.EntryViewBase;
+import impl.com.calendarfx.view.segments.SegmentedEntryViewSkin;
+
+/**
+ * Trait that allows segment updating its style properties when requested by {@link SegmentedEntryViewSkin}.
+ */
+public interface StyleAwareEntrySegmentTrait {
+
+    /**
+     * Called when views style change is detected. Should handle updating segments style.
+     *
+     * @param entryView entry view
+     */
+    void updateStyle(EntryViewBase<?> entryView);
+
+}

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/segments/SegmentedDayEntryViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/segments/SegmentedDayEntryViewSkin.java
@@ -1,0 +1,66 @@
+package impl.com.calendarfx.view.segments;
+
+import com.calendarfx.view.DayEntryView;
+import com.calendarfx.view.DayView;
+import com.calendarfx.view.segments.SegmentedDayEntryView;
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import com.calendarfx.view.segments.basic.TitleSegment;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.WeakInvalidationListener;
+
+import java.util.Comparator;
+
+/**
+ * Extended "bridge" implementation of {@link SegmentedEntryViewSkin} for use with {@link SegmentedDayEntryView}.
+ */
+public class SegmentedDayEntryViewSkin extends SegmentedEntryViewSkin<DayView> {
+
+    private static final Comparator<EntrySegmentBase> PRIORITIZE_TITLE_SEGMENT_COMPARATOR =
+            Comparator.comparingInt(segment -> (segment instanceof TitleSegment ? 0 : 1));
+
+    private final InvalidationListener minHeightEqualToTitleListener =(Observable o) -> updateSegments();
+    private final WeakInvalidationListener minHeightEqualToTitleWeakListener = new WeakInvalidationListener(minHeightEqualToTitleListener);
+
+    public SegmentedDayEntryViewSkin(SegmentedDayEntryView view) {
+        super(view);
+        view.minHeightEqualToTitleHeightProperty().addListener(minHeightEqualToTitleWeakListener);
+    }
+
+    /**
+     * If we declare that the minimum height is equal to height required by title segments (here we assume we
+     * could have more than one), we need to give them maximum priority during measurement phase. Otherwise
+     * when entry has minimal height, segments with higher visibility weight could take place of
+     * title segments.
+     */
+    @Override
+    protected Comparator<EntrySegmentBase> getVisibilityPriorityComparator() {
+        final Comparator<EntrySegmentBase> defaultComparator = super.getVisibilityPriorityComparator();
+        if (isMinHeightEqualToTitleHeight()) {
+            return (segmentA, segmentB) -> {
+                final int result = PRIORITIZE_TITLE_SEGMENT_COMPARATOR.compare(segmentA, segmentB);
+                return result != 0 ? result : defaultComparator.compare(segmentA, segmentB);
+            };
+        }
+        return defaultComparator;
+    }
+
+    @Override
+    protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
+        if (isMinHeightEqualToTitleHeight()) {
+            return computeTotalTitleSegmentsHeight() + topInset + bottomInset;
+        }
+        return super.computeMinHeight(width, topInset, rightInset, bottomInset, leftInset);
+    }
+
+    private double computeTotalTitleSegmentsHeight() {
+        return getSegments().stream()
+                .filter(TitleSegment.class::isInstance)
+                .map(segment -> segment.getNode().prefHeight(-1))
+                .reduce(0.0, Double::sum);
+    }
+
+    private boolean isMinHeightEqualToTitleHeight() {
+        return ((DayEntryView)getSkinnable()).isMinHeightEqualToTitleHeight();
+    }
+}

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/segments/SegmentedEntryViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/segments/SegmentedEntryViewSkin.java
@@ -1,0 +1,381 @@
+package impl.com.calendarfx.view.segments;
+
+import com.calendarfx.model.Calendar;
+import com.calendarfx.model.Entry;
+import com.calendarfx.util.ViewHelper;
+import com.calendarfx.view.DateControl;
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.segments.base.EntrySegmentBase;
+import com.calendarfx.view.segments.basic.StartTimeSegment;
+import com.calendarfx.view.segments.basic.TitleSegment;
+import com.calendarfx.view.segments.traits.ReactiveEntrySegmentTrait;
+import com.calendarfx.view.segments.traits.SegmentedEntryViewTrait;
+import com.calendarfx.view.segments.traits.StyleAwareEntrySegmentTrait;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.WeakInvalidationListener;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.control.SkinBase;
+import javafx.scene.shape.Rectangle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Implementation of {@link SkinBase} that uses {@link EntrySegmentBase} as basic layout element. Segments
+ * gives more control over what should be visible where there is not enough space to show all contained visual
+ * elements ({@link Node}). This implementation aligns segments from top to bottom with taking into the
+ * account theirs importance (visibility weight), vertical alignment and order. By default most influential
+ * property of segment is visibility weight, but in extending classes this could be adjusted
+ * by overriding {@link #getVisibilityPriorityComparator()}.
+ */
+public class SegmentedEntryViewSkin<T extends DateControl> extends SkinBase<EntryViewBase<T>>
+{
+    /**
+     * Helper internal class to store measurement of segments result, used later during segments positioning phase.
+     */
+    private static class MeasurementResult
+    {
+        double topRangeStart;
+        double centerRangeStart;
+        double bottomRangeStart;
+
+        public MeasurementResult(double topRangeStart, double centerRangeStart, double bottomRangeStart) {
+            this.topRangeStart = topRangeStart;
+            this.centerRangeStart = centerRangeStart;
+            this.bottomRangeStart = bottomRangeStart;
+        }
+
+        public double getTopRangeStart() {
+            return topRangeStart;
+        }
+
+        public double getCenterRangeStart() {
+            return centerRangeStart;
+        }
+
+        public double getBottomRangeStart() {
+            return bottomRangeStart;
+        }
+    }
+
+    /**
+     * Segments with value of visibility weight equal or above the threshold will be counted towards minimum
+     * height computation.
+     */
+    public static final int DEFAULT_VISIBILITY_WEIGHT_THRESHOLD = 10;
+
+    private final InvalidationListener updateStylesListener = it -> updateStyles();
+    private final WeakInvalidationListener weakUpdateStylesListener = new WeakInvalidationListener(updateStylesListener);
+
+    private List<EntrySegmentBase> segments;
+    private MeasurementResult lastMeasurement;
+
+    public SegmentedEntryViewSkin(EntryViewBase<T> view)
+    {
+        super(view);
+
+        applyClipping(view);
+
+        enableSegmentAutoUpdates(view);
+        updateSegments();
+
+        enableStyleAutoUpdates(view);
+        updateStyles();
+    }
+
+    /**
+     * Connects listener to update skin segments every time underlying views segments collection is modified.
+     * Listener is added only for views with certain trait: {@link SegmentedEntryViewTrait} which defines the
+     * interface how the segments should be provided to skin implementation and managed.
+     *
+     * @param view entry view
+     */
+    protected final void enableSegmentAutoUpdates(EntryViewBase<T> view) {
+        if (view instanceof SegmentedEntryViewTrait) {
+            ((SegmentedEntryViewTrait) view).segmentsProperty().addListener((Observable it) -> updateSegments());
+        }
+    }
+
+    /**
+     * Collects provided segments from view and creates default segments defined by the skin. Updates children
+     * of this skin with provided by segments nodes. If segment has {@link ReactiveEntrySegmentTrait} it calls
+     * its observe method, so it can add its listeners.
+     */
+    protected void updateSegments() {
+        final EntryViewBase<T> view = getSkinnable();
+
+        segments = new ArrayList<>();
+        segments.addAll(createDefaultSegments(view));
+        segments.addAll(getAdditionalViewSegments(view));
+
+        getChildren().clear();
+        segments.stream()
+                .map(EntrySegmentBase::getNode)
+                .forEach(getChildren()::add);
+
+        segments.stream()
+                .filter(ReactiveEntrySegmentTrait.class::isInstance)
+                .map(ReactiveEntrySegmentTrait.class::cast)
+                .forEach(segment -> segment.observe(getSkinnable()));
+    }
+
+    private void applyClipping(EntryViewBase<T> view) {
+        Rectangle clip = new Rectangle();
+        clip.widthProperty().bind(view.widthProperty());
+        clip.heightProperty().bind(view.heightProperty());
+        view.setClip(clip);
+    }
+
+    /**
+     * Creates default collection of segments.
+     *
+     * @param entryView entry view for which segments should be created
+     * @return list of default segments
+     */
+    protected List<EntrySegmentBase> createDefaultSegments(EntryViewBase<T> entryView) {
+        ArrayList<EntrySegmentBase> segments = new ArrayList<>();
+        segments.add(new TitleSegment(DEFAULT_VISIBILITY_WEIGHT_THRESHOLD, VPos.TOP));
+        segments.add(new StartTimeSegment(DEFAULT_VISIBILITY_WEIGHT_THRESHOLD - 1, VPos.TOP));
+        return segments;
+    }
+
+    /**
+     * Collects additional segments provided by the entry view.
+     *
+     * @param view entry view
+     * @return list of addition segments provided by the entry view
+     */
+    protected List<EntrySegmentBase> getAdditionalViewSegments(EntryViewBase<T> view) {
+        if (view instanceof SegmentedEntryViewTrait) {
+            return ((SegmentedEntryViewTrait) view).getSegments();
+        }
+        return Collections.emptyList();
+    }
+
+    protected final void enableStyleAutoUpdates(EntryViewBase<T> aView) {
+        ViewHelper.getEntry(aView).calendarProperty().addListener(weakUpdateStylesListener);
+    }
+
+    /**
+     * This methods updates the styles of the node according to the entry
+     * settings.
+     */
+    protected void updateStyles()
+    {
+        final EntryViewBase<T> view = getSkinnable();
+        final Entry<?> entry = ViewHelper.getEntry(view);
+        final Calendar calendar = ViewHelper.getCalendar(view);
+
+        if (calendar == null) {
+            return;
+        }
+
+        view.getStyleClass().setAll("default-style-entry", calendar.getStyle() + "-entry");
+
+        if (entry.isRecurrence()) {
+            view.getStyleClass().add("recurrence");
+        }
+
+        view.getStyleClass().addAll(entry.getStyleClass());
+
+        updateSegmentsStyle();
+    }
+
+    private void updateSegmentsStyle() {
+        segments.stream()
+                .filter(StyleAwareEntrySegmentTrait.class::isInstance)
+                .map(StyleAwareEntrySegmentTrait.class::cast)
+                .forEach(segment -> segment.updateStyle(getSkinnable()));
+    }
+
+    @Override
+    protected void layoutChildren(double x, double y, double width, double height) {
+        final List<EntrySegmentBase> sortedByOrder = new ArrayList<>(segments);
+        sortedByOrder.sort(Comparator.comparingInt(EntrySegmentBase::getOrder));
+
+        // measurement phase
+        measureSegments(sortedByOrder, x, y, width, height);
+
+        // positioning phase
+        positionSegments(sortedByOrder, x, y, width, height);
+    }
+
+    /**
+     * Measures space required by contained segments, if not enough space is available segments with lower
+     * importance (lower visibility weight and higher order value) are set to be invisible.
+     *
+     * After first not fitting segment is found the rest is ignored (theirs visibility set to hidden).
+     *
+     * @param orderedSegments vertically sorted (top to bottom) segments
+     * @param x contents x
+     * @param y contents y
+     * @param width contents width
+     * @param height contents height
+     */
+    protected void measureSegments(List<EntrySegmentBase> orderedSegments, double x, double y, double width, double height) {
+        double usedSpaceTotal = 0.0;
+        double usedSpaceTop = 0.0;
+        double usedSpaceBottom = 0.0;
+
+        List<EntrySegmentBase> sortedByWeight = new ArrayList<>(orderedSegments);
+        sortedByWeight.sort(getVisibilityPriorityComparator());
+
+        boolean isAllSpaceReserved = false;
+
+        for (EntrySegmentBase segment : sortedByWeight) {
+            final Node node = segment.getNode();
+
+            if (isAllSpaceReserved) {
+                node.setVisible(false);
+                continue;
+            }
+
+            segment.prepareLayout(getSkinnable(), width, height);
+
+            final double preferredHeight = node.prefHeight(width);
+            if (usedSpaceTotal + preferredHeight <= height) {
+                usedSpaceTotal += preferredHeight;
+
+                switch (segment.getAlignment()) {
+                    case TOP:
+                        usedSpaceTop += preferredHeight;
+                        break;
+                    case BOTTOM:
+                    case BASELINE:
+                        usedSpaceBottom += preferredHeight;
+                        break;
+                    default:
+                }
+
+                markSegmentAsUsable(segment);
+            } else {
+                markSegmentAsIgnored(segment);
+                isAllSpaceReserved = true;
+            }
+        }
+
+        double optimisticCenterRangeStart = y + (height * 0.5) - (usedSpaceTotal - (usedSpaceTop + usedSpaceBottom)) * 0.5;
+
+        final MeasurementResult result = new MeasurementResult(
+                0.0,
+                Math.max(optimisticCenterRangeStart, usedSpaceTop),
+                height - usedSpaceBottom);
+        setLastMeasurement(result);
+    }
+
+    /**
+     * Provides comparator used during measurement phase for deciding priority of segments which should stay
+     * visible. By default priority should be defined by visibility weight, but this could be adjusted in
+     * extending classes.
+     *
+     * @return comparator
+     */
+    protected Comparator<EntrySegmentBase> getVisibilityPriorityComparator() {
+        return Comparator.comparingInt(EntrySegmentBase::getVisibilityWeight).reversed();
+    }
+
+    /**
+     * Positions segments using lastly measured space usage {@link MeasurementResult}. Segments set to be
+     * invisible during measurement phase will be not positioned.
+     *
+     * @param orderedSegments vertically sorted (top to bottom) segments
+     * @param x contents x
+     * @param y contents y
+     * @param width contents width
+     * @param height contents height
+     */
+    protected void positionSegments(List<EntrySegmentBase> orderedSegments, double x, double y, double width, double height) {
+        MeasurementResult measurement = getLastMeasurement();
+
+        double topPointer = measurement.getTopRangeStart();
+        double centerPointer = measurement.getCenterRangeStart();
+        double bottomPointer = measurement.getBottomRangeStart();
+
+        for (EntrySegmentBase segment : orderedSegments)
+        {
+            final Node node = segment.getNode();
+            if (isSegmentMarkedAsUsable(segment))
+            {
+                final double nodeHeight = node.prefHeight(width);
+
+                final double computedY;
+                switch (segment.getAlignment()) {
+                    case TOP:
+                        computedY = y + topPointer;
+                        topPointer += nodeHeight;
+                        break;
+                    case CENTER:
+                        computedY = y + centerPointer;
+                        centerPointer += nodeHeight;
+                        break;
+                    default:
+                    case BOTTOM:
+                    case BASELINE:
+                        computedY = y + bottomPointer;
+                        bottomPointer += nodeHeight;
+                        break;
+                }
+
+                node.resizeRelocate(snapPositionX(x), snapPositionY(computedY), snapSizeX(width), snapSizeY(nodeHeight));
+            }
+        }
+    }
+
+    @Override
+    protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return segments.stream()
+                .filter(segment -> segment.getVisibilityWeight() >= DEFAULT_VISIBILITY_WEIGHT_THRESHOLD)
+                .map(EntrySegmentBase::getNode)
+                .map(node -> node.prefHeight(-1))
+                .reduce(0.0, Double::sum) + topInset + bottomInset;
+    }
+
+    /**
+     * Called during measurement phase. Marks segment as usable during positioning stage by setting visibility of segments node to true.
+     *
+     * @param segment segment
+     */
+    protected void markSegmentAsUsable(EntrySegmentBase segment) {
+        segment.getNode().setVisible(true);
+    }
+
+    /**
+     * Called during measurement phase. Marks segment as ignored by setting visibility of segments node to false.
+     *
+     * @param segment segment
+     */
+    protected void markSegmentAsIgnored(EntrySegmentBase segment) {
+        segment.getNode().setVisible(false);
+    }
+
+    /**
+     * Called during positioning phase. Returns true if segment was marked as usable during measurement phase.
+     *
+     * @param segment segment
+     * @return true if segment should be used during positioning phase
+     */
+    protected boolean isSegmentMarkedAsUsable(EntrySegmentBase segment) {
+        return segment.getNode().isVisible();
+    }
+
+    /**
+     * Gives access to read-only list of segments for extending classes.
+     *
+     * @return read-only list of segments
+     */
+    protected final List<EntrySegmentBase> getSegments() {
+        return Collections.unmodifiableList(segments);
+    }
+
+    private MeasurementResult getLastMeasurement() {
+        return lastMeasurement;
+    }
+
+    private void setLastMeasurement(MeasurementResult measurement) {
+        lastMeasurement = measurement;
+    }
+}

--- a/CalendarFXView/src/main/java/module-info.java
+++ b/CalendarFXView/src/main/java/module-info.java
@@ -15,12 +15,17 @@ module com.calendarfx.view {
     exports com.calendarfx.view.page;
     exports com.calendarfx.view.popover;
     exports com.calendarfx.view.print;
+    exports com.calendarfx.view.segments;
+    exports com.calendarfx.view.segments.base;
+    exports com.calendarfx.view.segments.basic;
+    exports com.calendarfx.view.segments.traits;
 
     exports impl.com.calendarfx.view;
     exports impl.com.calendarfx.view.page;
     exports impl.com.calendarfx.view.popover;
     exports impl.com.calendarfx.view.print;
     exports impl.com.calendarfx.view.util;
+    exports impl.com.calendarfx.view.segments;
 
     opens com.calendarfx.view;
 }


### PR DESCRIPTION
Hello Dirk,
as follow up of https://github.com/dlsc-software-consulting-gmbh/CalendarFX/issues/107 we have prepared for you a PR with functionality that is important to us: an alternative layout mechanism for aligning visual elements (labels, shapes, panes etc.) inside of the calendars entry, which helps to adjust visibility of contained information.

The reasoning standing behind this functionality is that we are displaying a lot of information inside of the entries, often using "high-resolution" views (showing multiple days, where en-tries have little space to use). In those situations we need to control priority of the presented information, and deal with the problem of not having enough space to display everything. Moreover we needed a way for structure contained visual elements so they do not overlap on each other.

The implementation is based on mentioned earlier "segments", those are the basic building blocks of this implementation. The layout mechanism itself is a separate alternative for the existing one (please see SegmentedEntryView/SegmentedEntryViewSkin classes) but should be also a compatible extension of it (please see SegmentedDayEntryView/SegmentedDayEntryViewSkin classes).

As a quick demonstration we have modified ResourceCalendarApp, so it better reflects some of our use scenarios. Inside of the source file of ResourceCalendarApp are comments which describe functionality with more details.

Please let us know what do you think about the PR, and most importantly after reviewing it: if the code will be accepted by you as a code donation?

Best regards,
PSI Polska - ASM Team