### PR TITLE
Require public API dependencies transitively

### DIFF
--- a/CalendarFXApp/src/main/java/module-info.java
+++ b/CalendarFXApp/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module com.calendarfx.app {
+    requires transitive javafx.graphics;
 
     requires javafx.controls;
     requires com.calendarfx.view;

--- a/CalendarFXGoogle/src/main/java/module-info.java
+++ b/CalendarFXGoogle/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module com.calendarfx.google {
+    requires transitive javafx.graphics;
 
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.fontawesome;
@@ -7,7 +8,6 @@ module com.calendarfx.google {
     requires com.calendarfx.view;
     requires javafx.base;
     requires com.google.api.services.calendar;
-    requires javafx.graphics;
     requires org.controlsfx.controls;
     requires javafx.controls;
     requires javafx.web;

--- a/CalendarFXResourceApp/src/main/java/module-info.java
+++ b/CalendarFXResourceApp/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module com.calendarfx.app {
+    requires transitive javafx.graphics;
 
     requires javafx.controls;
     requires com.calendarfx.view;

--- a/CalendarFXSampler/src/main/java/module-info.java
+++ b/CalendarFXSampler/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 open module com.calendarfx.sampler {
+    requires transitive org.controlsfx.fxsampler;
+    requires transitive javafx.graphics;
 
     requires javafx.web;
-
-    requires org.controlsfx.fxsampler;
 
     requires com.calendarfx.view;
 

--- a/CalendarFXWeather/src/main/java/module-info.java
+++ b/CalendarFXWeather/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 module com.calendarfx.weather {
+    requires transitive javafx.graphics;
+
     requires javafx.controls;
     requires com.calendarfx.view;
     requires org.kordamp.ikonli.javafx;

--- a/CalendarFXiCal/src/main/java/module-info.java
+++ b/CalendarFXiCal/src/main/java/module-info.java
@@ -1,7 +1,8 @@
 module com.calendarfx.ical {
+    requires transitive org.mnode.ical4j.core;
+    requires transitive com.calendarfx.view;
+
     requires java.logging;
-    requires com.calendarfx.view;
-    requires org.mnode.ical4j.core;
 
     exports com.calendarfx.ical;
     exports com.calendarfx.ical.model;


### PR DESCRIPTION
This resolves warnings emitted by Visual Studio Code related to not requiring modules transitively, whose classes are being used in the public API of the corresponding module.

What do you think?