### PR TITLE
Top layer view entries

### DIFF
--- a/CalendarFXGoogle/src/main/java/module-info.java
+++ b/CalendarFXGoogle/src/main/java/module-info.java
@@ -3,7 +3,7 @@ module com.calendarfx.google {
 
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.fontawesome;
-    requires org.kordamp.iconli.core;
+    requires org.kordamp.ikonli.core;
 
     requires com.calendarfx.view;
     requires javafx.base;

--- a/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
+++ b/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
@@ -23,6 +23,8 @@ import com.calendarfx.model.Entry;
 import com.calendarfx.model.Marker;
 import com.calendarfx.view.DayEntryView;
 import com.calendarfx.view.DayView;
+import com.calendarfx.view.EntryViewBase;
+import com.calendarfx.view.EntryViewBase.Layer;
 import com.calendarfx.view.ResourceCalendarView;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -42,8 +44,14 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.util.Random;
+import java.util.function.Supplier;
 
 public class ResourceCalendarApp extends Application {
+
+    public static final int DATA_GENERATION_SEED = 11011;
+
+    final Random random = new Random(DATA_GENERATION_SEED);
 
     @Override
     public void start(Stage primaryStage) {
@@ -90,17 +98,25 @@ public class ResourceCalendarApp extends Application {
         for (int i = 0; i < 5; i++) {
             CalendarSource source = new CalendarSource("Default");
 
-            Calendar calendar1 = new HelloDayViewCalendar();
+            HelloDayViewCalendar calendar1 = new HelloDayViewCalendar(random.nextLong());
+            calendar1.generateBaseEntries();
             calendar1.setStyle(Style.STYLE1);
             source.getCalendars().add(calendar1);
 
-            Calendar calendar2 = new HelloDayViewCalendar();
+            HelloDayViewCalendar calendar2 = new HelloDayViewCalendar(random.nextLong());
+            calendar2.generateBaseEntries();
             calendar2.setStyle(Style.STYLE2);
             source.getCalendars().add(calendar2);
 
-            Calendar calendar3 = new HelloDayViewCalendar();
+            HelloDayViewCalendar calendar3 = new HelloDayViewCalendar(random.nextLong());
+            calendar3.generateBaseEntries();
             calendar3.setStyle(Style.STYLE3);
             source.getCalendars().add(calendar3);
+
+            HelloDayViewCalendar calendar4 = new HelloDayViewCalendar(random.nextLong());
+            calendar4.generateTopEntries();
+            calendar4.setStyle(Style.STYLE4);
+            source.getCalendars().add(calendar4);
 
             String resource = "Resource " + (i + 1);
             resourceCalendarView.getResources().add(resource);
@@ -114,9 +130,19 @@ public class ResourceCalendarApp extends Application {
              * Setting a custom entry view factory will allow you to set icons on your entry
              * views based on state information provided by your model.
              */
+
+            Random iconsRandom = new Random();
+
             dayView.setEntryViewFactory(entry -> {
+                iconsRandom.setSeed(entry.getTitle().hashCode());
 
                 DayEntryView entryView = new DayEntryView(entry);
+
+                if (entry instanceof TopEntry) {
+                    entryView.setWidthPercentage(25.0);
+                    entryView.setAlignmentStrategy(EntryViewBase.AlignmentStrategy.ALIGN_RIGHT);
+                    entryView.setLayer(Layer.TOP);
+                }
 
                 /* PSI:
                  * Here you can experiment with the new alignment strategy that allows
@@ -135,28 +161,28 @@ public class ResourceCalendarApp extends Application {
                  */
                 // entryView.setHeightLayoutStrategy(HeightLayoutStrategy.COMPUTE_PREF_SIZE);
 
-                if (Math.random() > .7) {
+                if (iconsRandom.nextDouble() > .7) {
                     final FontIcon node = new FontIcon(FontAwesome.ERASER);
                     node.setIconColor(Color.RED);
                     node.setIconSize(16);
                     entryView.addNode(Pos.BOTTOM_RIGHT, node);
                 }
 
-                if (Math.random() > .9) {
+                if (iconsRandom.nextDouble() > .9) {
                     final FontIcon node = new FontIcon(FontAwesome.CODE);
                     node.setIconColor(Color.BLUE);
                     node.setIconSize(16);
                     entryView.addNode(Pos.BOTTOM_RIGHT, node);
                 }
 
-                if (Math.random() > .7) {
+                if (iconsRandom.nextDouble() > .7) {
                     final FontIcon node = new FontIcon(FontAwesome.QRCODE);
                     node.setIconColor(Color.MEDIUMPURPLE);
                     node.setIconSize(16);
                     entryView.addNode(Pos.BOTTOM_RIGHT, node);
                 }
 
-                if (Math.random() > .7) {
+                if (iconsRandom.nextDouble() > .7) {
                     final FontIcon node = new FontIcon(FontAwesome.SIGN_IN);
                     node.setIconColor(Color.MEDIUMSPRINGGREEN);
                     node.setIconSize(16);
@@ -219,24 +245,35 @@ public class ResourceCalendarApp extends Application {
 
     class HelloDayViewCalendar extends Calendar {
 
-        public HelloDayViewCalendar() {
-            createEntries(LocalDate.now().minusDays(2));
-            createEntries(LocalDate.now().minusDays(1));
-            createEntries(LocalDate.now());
-            createEntries(LocalDate.now().plusDays(1));
-            createEntries(LocalDate.now().plusDays(2));
+        final Random dataRandom = new Random();
+
+        public HelloDayViewCalendar(long dataSeed) {
+            dataRandom.setSeed(dataSeed);
         }
 
-        private void createEntries(LocalDate startDate) {
-            for (int j = 0; j < 5 + (int) (Math.random() * 4); j++) {
-                Entry<?> entry = new Entry<>();
+        public void generateBaseEntries() {
+            createEntries(LocalDate.now().minusDays(2), Entry::new);
+            createEntries(LocalDate.now().minusDays(1), Entry::new);
+            createEntries(LocalDate.now(), Entry::new);
+            createEntries(LocalDate.now().plusDays(1), Entry::new);
+            createEntries(LocalDate.now().plusDays(2), Entry::new);
+        }
+
+        public void generateTopEntries() {
+            createEntries(LocalDate.now(), TopEntry::new);
+        }
+
+        private <T extends Entry<?>> void createEntries(LocalDate startDate, Supplier<T> entryProducer) {
+            for (int j = 0; j < 5 + (int) (dataRandom.nextDouble() * 4); j++) {
+                T entry = entryProducer.get();
                 entry.changeStartDate(startDate);
                 entry.changeEndDate(startDate);
 
-                entry.setTitle("Entry " + (j + 1));
+                String s = entry.getClass().getSimpleName();
+                entry.setTitle(s + (j + 1));
 
-                int hour = (int) (Math.random() * 23);
-                int durationInHours = Math.max(1, Math.min(24 - hour, (int) (Math.random() * 4)));
+                int hour = (int) (dataRandom.nextDouble() * 23);
+                int durationInHours = Math.max(1, Math.min(24 - hour, (int) (dataRandom.nextDouble() * 4)));
 
                 LocalTime startTime = LocalTime.of(hour, 0);
                 LocalTime endTime = startTime.plusHours(durationInHours);
@@ -251,5 +288,9 @@ public class ResourceCalendarApp extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+    public static class TopEntry<T> extends Entry<T>
+    {
     }
 }

--- a/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
+++ b/CalendarFXResourceApp/src/main/java/com/calendarfx/resource/app/ResourceCalendarApp.java
@@ -21,10 +21,10 @@ import com.calendarfx.model.Calendar.Style;
 import com.calendarfx.model.CalendarSource;
 import com.calendarfx.model.Entry;
 import com.calendarfx.model.Marker;
+import com.calendarfx.view.DateControl;
 import com.calendarfx.view.DayEntryView;
 import com.calendarfx.view.DayView;
 import com.calendarfx.view.EntryViewBase;
-import com.calendarfx.view.EntryViewBase.Layer;
 import com.calendarfx.view.ResourceCalendarView;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -141,7 +141,7 @@ public class ResourceCalendarApp extends Application {
                 if (entry instanceof TopEntry) {
                     entryView.setWidthPercentage(25.0);
                     entryView.setAlignmentStrategy(EntryViewBase.AlignmentStrategy.ALIGN_RIGHT);
-                    entryView.setLayer(Layer.TOP);
+                    entryView.setLayer(DateControl.Layer.TOP);
                 }
 
                 /* PSI:

--- a/CalendarFXSampler/src/main/java/com/calendarfx/demo/views/HelloTopLayer.java
+++ b/CalendarFXSampler/src/main/java/com/calendarfx/demo/views/HelloTopLayer.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2017 Dirk Lemmermann Software & Consulting (dlsc.com)
+ *  Copyright (C) 2006 Google Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.calendarfx.demo.views;
+
+import com.calendarfx.demo.CalendarFXSample;
+import com.calendarfx.model.Calendar;
+import com.calendarfx.model.CalendarSource;
+import com.calendarfx.model.Entry;
+import com.calendarfx.view.DateControl;
+import com.calendarfx.view.DayEntryView;
+import com.calendarfx.view.DayView;
+import com.calendarfx.view.DayViewBase;
+import com.calendarfx.view.EntryViewBase.AlignmentStrategy;
+import impl.com.calendarfx.view.CalendarPropertySheet;
+import javafx.scene.Node;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class HelloTopLayer extends CalendarFXSample {
+
+    private DayView dayView = new DayView();
+
+    @Override
+    public String getSampleName() {
+        return "Day View with Top Layer";
+    }
+
+    @Override
+    public Node getControlPanel() {
+        return new CalendarPropertySheet(dayView.getPropertySheetItems());
+    }
+
+    protected Node createControl() {
+        CalendarSource calendarSource = new CalendarSource();
+        calendarSource.getCalendars().add(new BaseLayerCalendar());
+        calendarSource.getCalendars().add(new TopLayerCalendar());
+        dayView.getCalendarSources().setAll(calendarSource);
+        dayView.setHoursLayoutStrategy(DayViewBase.HoursLayoutStrategy.FIXED_HOUR_HEIGHT);
+        dayView.setHourHeight(20);
+        dayView.setPrefWidth(200);
+
+        dayView.visibleLayersProperty().addAll(List.of(DateControl.Layer.BASE, DateControl.Layer.TOP));
+        dayView.setEntryViewFactory(this::createEntryView);
+
+        return dayView;
+    }
+
+    private DayEntryView createEntryView(Entry<?> entry) {
+        DayEntryView entryView = new DayEntryView(entry);
+        if (entry.getCalendar() instanceof TopLayerCalendar) {
+            entryView.setLayer(DateControl.Layer.TOP);
+            entryView.setWidthPercentage(20.0);
+            entryView.setAlignmentStrategy(AlignmentStrategy.ALIGN_RIGHT);
+        }
+        return entryView;
+    }
+
+    @Override
+    public String getSampleDescription() {
+        return "The day view supports base and top layers functionality.";
+    }
+
+    @Override
+    protected Class<?> getJavaDocClass() {
+        return DayView.class;
+    }
+
+    static class BaseLayerCalendar extends Calendar {
+
+        public BaseLayerCalendar() {
+            createCalendarEntries(this, "Entry", LocalDate.now());
+            setStyle(Style.STYLE1);
+        }
+
+    }
+
+    static class TopLayerCalendar extends Calendar {
+
+        public TopLayerCalendar() {
+            createCalendarEntries(this, "Note", LocalDate.now());
+            setStyle(Style.STYLE2);
+        }
+
+    }
+
+    private static void createCalendarEntries(Calendar calendar, String titlePrefix, LocalDate startDate) {
+        for (int j = 0; j < 5 + (int) (Math.random() * 7); j++) {
+            Entry<?> entry = new Entry<>();
+            entry.changeStartDate(startDate);
+            entry.changeEndDate(startDate);
+
+            entry.setTitle(titlePrefix + " " + (j + 1));
+
+            int hour = (int) (Math.random() * 23);
+            int durationInHours = Math.max(1, Math.min(24 - hour, (int) (Math.random() * 4)));
+
+            LocalTime startTime = LocalTime.of(hour, 0);
+            LocalTime endTime = startTime.plusHours(durationInHours);
+
+            entry.changeStartTime(startTime);
+            entry.changeEndTime(endTime);
+
+            entry.setCalendar(calendar);
+        }
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
@@ -423,6 +423,29 @@ public abstract class DateControl extends CalendarFXControl {
         prop.set(visible);
     }
 
+    public enum Layer {
+
+        /**
+         * Base (and default) presentation layer for entry views.
+         */
+        BASE,
+
+        /**
+         * Top presentation layer for entry views. Presented view entries will be visible above base layer.
+         * Uses simple layout system, which does not support resolving of overlapping entries.
+         */
+        TOP
+    }
+
+    private final ObservableSet<Layer> visibleLayers = FXCollections.observableSet(Layer.BASE, Layer.TOP);
+
+    /**
+     * Collection of layers which should be visible/presented.
+     */
+    public final ObservableSet<Layer> visibleLayersProperty() {
+        return visibleLayers;
+    }
+
     /**
      * Requests that the date control should reload its data and recreate its
      * entry views. Normally applications do not have to call this method. It is
@@ -697,6 +720,8 @@ public abstract class DateControl extends CalendarFXControl {
         PopOver datePopOver = new DatePopOver(this, date);
         datePopOver.show(owner);
     }
+
+
 
     private abstract static class ContextMenuParameterBase {
 
@@ -2980,6 +3005,87 @@ public abstract class DateControl extends CalendarFXControl {
             }
         });
 
+        items.add(new Item() {
+            @Override
+            public Optional<ObservableValue<? extends Object>> getObservableValue() {
+                return Optional.empty();
+            }
+
+            @Override
+            public void setValue(Object value) {
+                if ((Boolean) value) {
+                    visibleLayersProperty().add(Layer.BASE);
+                } else {
+                    visibleLayersProperty().remove(Layer.BASE);
+                }
+            }
+
+            @Override
+            public Object getValue() {
+                return visibleLayersProperty().contains(Layer.BASE);
+            }
+
+            @Override
+			public Class<?> getType() {
+				return Boolean.class;
+			}
+
+            @Override
+            public String getName() {
+                return "Base Layer";
+            }
+
+			@Override
+			public String getDescription() {
+				return "Base Layer visible / hidden";
+			}
+
+            @Override
+            public String getCategory() {
+                return DATE_CONTROL_CATEGORY;
+            }
+		});
+
+        items.add(new Item() {
+            @Override
+            public Optional<ObservableValue<? extends Object>> getObservableValue() {
+                return Optional.empty();
+            }
+
+            @Override
+            public void setValue(Object value) {
+                if ((Boolean) value) {
+                    visibleLayersProperty().add(Layer.TOP);
+                } else {
+                    visibleLayersProperty().remove(Layer.TOP);
+                }
+            }
+
+            @Override
+            public Object getValue() {
+                return visibleLayersProperty().contains(Layer.TOP);
+            }
+
+            @Override
+            public Class<?> getType() {
+                return Boolean.class;
+            }
+
+            @Override
+            public String getName() {
+                return "Top Layer";
+            }
+
+            @Override
+            public String getDescription() {
+                return "Top Layer visible / hidden";
+            }
+
+            @Override
+            public String getCategory() {
+                return DATE_CONTROL_CATEGORY;
+            }
+        });
 
         return items;
     }

--- a/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/EntryViewBase.java
@@ -26,12 +26,14 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -461,6 +463,20 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
         ONLY
     }
 
+    public enum Layer {
+
+        /**
+         * Base (and default) presentation layer for entry views.
+         */
+        BASE,
+
+        /**
+         * Top presentation layer for entry views. Presented view entries will be visible above base layer.
+         * Uses simple layout system, which does not support resolving of overlapping entries.
+         */
+        TOP
+    }
+
     private Position _position = Position.ONLY;
 
     private ReadOnlyObjectWrapper<Position> position;
@@ -845,6 +861,109 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
         return selectedProperty().get();
     }
 
+    /**
+     * Entry presentation layer.
+     */
+
+    private Layer _layer = Layer.BASE;
+
+    private ObjectProperty<Layer> layer;
+
+    /**
+     * Layer on which entry will be presented. For possible values please check {@link Layer}.
+     *
+     * @return the entry presentation layer
+     */
+    public final ObjectProperty<Layer> layerProperty() {
+        if (layer == null) {
+            layer = new SimpleObjectProperty<>(this, "layer", _layer);
+        }
+        return layer;
+    }
+
+    /**
+     * Returns the value of {@link #layerProperty()}.
+     *
+     * @return the entry presentation layer
+     */
+    public final Layer getLayer() {
+        return layer == null ? _layer : layer.get();
+    }
+
+    /**
+     * Sets the value of {@link #layerProperty()}.
+     *
+     * @param layer the entry presentation layer
+     */
+    public final void setLayer(Layer layer) {
+        if (this.layer == null) {
+            _layer = layer;
+        } else {
+            this.layer.set(layer);
+        }
+    }
+
+    /**
+     * Width percentage of entry view.
+     */
+
+    private Double _widthPercentage = 100.0;
+
+    private DoubleProperty widthPercentage;
+
+    /**
+     * A percentage value used to specify how much of the available width inside the
+     * view will be utilized by the entry views. The default value is 100%, however
+     * applications might want to set a smaller value to allow the user to click and
+     * create new entries in already used time intervals.
+     * <p>
+     * Width percentage is only used for width computation when {@link #prefWidthProperty()}
+     * of view entry has no defined value and when {@link #alignmentStrategyProperty()}
+     * is not {@link AlignmentStrategy#FILL}.
+     *</p>
+     * @return the entry percentage width
+     */
+    public final DoubleProperty widthPercentageProperty() {
+        if (widthPercentage == null) {
+            widthPercentage = new SimpleDoubleProperty(this, "widthPercentage", _widthPercentage) {
+                @Override
+                public void set(double percentage) {
+                    validateWidthPercentageProperty(percentage);
+                    super.set(percentage);
+                }
+            };
+        }
+        return widthPercentage;
+    }
+
+    /**
+     * Returns the value of {@link #widthPercentageProperty()}.
+     *
+     * @return the entry percentage width
+     */
+    public double getWidthPercentage() {
+        return widthPercentage == null ? _widthPercentage : widthPercentage.get();
+    }
+
+    /**
+     * Sets the value of {@link #widthPercentage}.
+     *
+     * @param widthPercentage the new entry percentage width
+     */
+    public final void setWidthPercentage(double widthPercentage) {
+        if (this.widthPercentage == null) {
+            validateWidthPercentageProperty(widthPercentage);
+            _widthPercentage = widthPercentage;
+        } else {
+            this.widthPercentage.set(widthPercentage);
+        }
+    }
+
+    private void validateWidthPercentageProperty(double newValue) {
+        if (newValue < 0.0 || newValue > 100.0) {
+            throw new IllegalArgumentException("percentage width must be between 0 and 100 but was " + newValue);
+        }
+    }
 
     /**
      * Different strategies for determining the height of an entry view. Normally
@@ -852,7 +971,7 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
      * we might want to simply use the start time for its location and the required
      * height based on its content (e.g. the labels inside the entry view). The layout
      * strategy {@link HeightLayoutStrategy#COMPUTE_PREF_SIZE} disables changes to the end
-     * time of the entry as the bottom y coordiante of the view would not accurately
+     * time of the entry as the bottom y coordinate of the view would not accurately
      * represent the end time of the entry.
      *
      * @see DayViewBase#setOverlapResolutionStrategy(OverlapResolutionStrategy)
@@ -889,7 +1008,7 @@ public abstract class EntryViewBase<T extends DateControl> extends CalendarFXCon
      * entry's view on the left, the center, or the middle.
      * <p>
      *     If the time intervals of two entries are overlapping then the entries might
-     *     be placed in two columns. The alignment strategry would then determine the layout
+     *     be placed in two columns. The alignment strategy would then determine the layout
      *     of the entry within its column.
      * </p>
      *

--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewSkin.java
@@ -552,7 +552,7 @@ public class DayViewSkin<T extends DayView> extends DayViewBaseSkin<T> implement
         Map<Calendar, List<DayEntryView>> calendarGroupedEntryViews = groupEntryViewsBy(this::getEntryViewCalendar, entryViewFilter);
 
         for (Calendar calendar : visibleCalendars) {
-            Map<Layer, List<DayEntryView>> layerGroupedEntryViews = calendarGroupedEntryViews.get( calendar ).stream()
+            Map<Layer, List<DayEntryView>> layerGroupedEntryViews = calendarGroupedEntryViews.getOrDefault(calendar, Collections.emptyList()).stream()
                     .collect(Collectors.groupingBy(EntryViewBase::getLayer));
 
             layoutOnLayers(layerGroupedEntryViews, dayView, x, contentY, w, contentHeight);


### PR DESCRIPTION
Top layer for showing entries introduced.
Here is our reasoning behind the changes:
- instead of introducing "onTop" property, we have decided to create "layer" property, we hope the code will be more readable this way
- we split entries for layers before calling layout methods, each layer (BASE and TOP) now has its own layout method. Top layer uses simpler layout mechanics of simply placing items, without resolving overlapping entries.
- new widthPercentage property is only used for view entry width computation if no preferred width value is present
- in Swimlane mode, we are grouping entries for each calendar before layouting them, instead of filtering them for each calendar in the loop (it seems more efficient this way)
- the data in ResourceCalendarApp is now generated from seed, each time the example app is started the data should look the same if seed has not been changed
Also, while implementing the new feature, we have found two things that possbily might be bugs.
1) When using Alignment Strategy different than FILL and not defining value of preferred width of view entry, all entries have no width, and are not visible.
2) When using Alignment Strategy ALIGN_RIGHT in Swimlane mode, the offset of entry was not correctly computed:
```
	switch (entryView.getAlignmentStrategy()) {
		case ALIGN_RIGHT:
			x = columnWidth - w;
			break;
```
the correct formula probably is: `x = x + (columnWidth - w)`.
Our changes are addressing those two problems:
In 1) when no preferred width value is present, we simply use all available space (columnWidth or contentWidth).
In 2) the created function adds column offset.
We hope the code is fine and meets the requirements and standards of CalendarFX project 🙂 