### PR TITLE
Fixes "iconli" with a 'c'.

### DIFF
--- a/CalendarFXGoogle/src/main/java/module-info.java
+++ b/CalendarFXGoogle/src/main/java/module-info.java
@@ -3,7 +3,7 @@ module com.calendarfx.google {
 
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.fontawesome;
-    requires org.kordamp.iconli.core;
+    requires org.kordamp.ikonli.core;
 
     requires com.calendarfx.view;
     requires javafx.base;


### PR DESCRIPTION
I did a quick `grep -r iconli *` which didn't return anything, so it seems like the only one.

Related to issue #112.
