### PR TITLE
Add checks for null entry after DateControl.createEntryAt

### DIFF
--- a/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
+++ b/CalendarFXView/src/main/java/impl/com/calendarfx/view/DayViewEditController.java
@@ -202,7 +202,7 @@ public class DayViewEditController {
             Entry<?> entry = createEntryAt(evt);
             evt.consume();
 
-            if (view.isShowDetailsUponEntryCreation()) {
+            if (entry != null && view.isShowDetailsUponEntryCreation()) {
                 view.fireEvent(new RequestEvent(view, view, entry));
             }
         }
@@ -327,6 +327,9 @@ public class DayViewEditController {
 
         ZonedDateTime time = ZonedDateTime.ofInstant(instantAt, view.getZoneId());
         Entry<?> newEntry = view.createEntryAt(time, calendar.orElse(null), false);
+        if (newEntry == null) {
+            return null;
+        }
 
         Duration duration = newEntry.getMinimumDuration();
 
@@ -389,6 +392,9 @@ public class DayViewEditController {
 
             // Important, use the initial mouse event when the user pressed the button
             entry = createEntryAt(mousePressedEvent);
+            if (entry == null) {
+                return;
+            }
 
             DayView dayView = null;
 


### PR DESCRIPTION
Resolves a null pointer error after a double click or drag event attempts to create a new entry in a read only calendar.

This is because when a calendar is read only DateControl.createEntryAt(ZonedDateTime, Calendar, boolean) simply returns a null entry.
However, the calling code of the click or drag MouseEvent (DayViewEditController) does not check if the returned entry is null or not.

Replication:
Ensure the calendar in question is read only
Either double click or click and drag on an 'empty' space in the calendar to create a new entry
Null pointer exception is thrown

Error:
Caused by: java.lang.NullPointerException: Cannot invoke "com.calendarfx.model.Entry.getMinimumDuration()" because "newEntry" is null
	at deployment.efacs.ear//impl.com.calendarfx.view.DayViewEditController.createEntryAt(DayViewEditController.java:331)
	at deployment.efacs.ear//impl.com.calendarfx.view.DayViewEditController.mouseClicked(DayViewEditController.java:202)