### PR TITLE
Fix a bug with the date popover position and a bug with stacking

### DIFF
--- a/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
+++ b/CalendarFXView/src/main/java/com/calendarfx/view/DateControl.java
@@ -275,12 +275,12 @@ public abstract class DateControl extends CalendarFXControl {
         setDateDetailsCallback(param -> {
             InputEvent evt = param.getInputEvent();
             if (evt == null) {
-                param.getDateControl().showDateDetails(param.getOwner(), param.getLocalDate());
+                param.getDateControl().showDateDetails(param.getOwner(), param.getLocalDate(), param.getScreenX(), param.getScreenY());
                 return true;
             } else if (evt instanceof MouseEvent) {
                 MouseEvent mouseEvent = (MouseEvent) evt;
                 if (mouseEvent.getClickCount() == 1) {
-                    param.getDateControl().showDateDetails(param.getOwner(), param.getLocalDate());
+                    param.getDateControl().showDateDetails(param.getOwner(), param.getLocalDate(), param.getScreenX(), param.getScreenY());
                     return true;
                 }
             }
@@ -788,6 +788,8 @@ public abstract class DateControl extends CalendarFXControl {
         entryPopOver.show(owner, position.getX(), position.getY());
     }
 
+    private PopOver datePopOver;
+
     /**
      * Creates a new {@link DatePopOver} and shows it attached to the given
      * owner node.
@@ -795,9 +797,12 @@ public abstract class DateControl extends CalendarFXControl {
      * @param owner the owner node
      * @param date  the date for which to display more detail
      */
-    public void showDateDetails(Node owner, LocalDate date) {
-        PopOver datePopOver = new DatePopOver(this, date);
-        datePopOver.show(owner);
+    public void showDateDetails(Node owner, LocalDate date, double screenX, double screenY) {
+        if (datePopOver != null && datePopOver.isShowing()) {
+            datePopOver.hide();
+        }
+        datePopOver = new DatePopOver(this, date);
+        datePopOver.show(owner, screenX, screenY);
     }
 
     private abstract static class ContextMenuParameterBase {


### PR DESCRIPTION
This PR fixes 2 bugs related to the date details popover feature in the year page view.

1. The date details popover is now positioned where the mouse was clicked instead of at the edge of the entire view.
2. The popovers no longer stack, the previous is closed when a new popover is shown.

## Before

![explorer_9ZqCoLDbnD](https://github.com/user-attachments/assets/218d0a94-5be2-4200-9432-f6ba54e9c0fd)

## After

![java_2xYrJuyR5r](https://github.com/user-attachments/assets/8e519626-8979-42d0-a786-7a6944fdb034)
